### PR TITLE
Add `company_service`

### DIFF
--- a/internal/repositories/company_repository.go
+++ b/internal/repositories/company_repository.go
@@ -64,7 +64,7 @@ func (repository *CompanyRepository) Create(company *models.CreateCompany) (*mod
 	result, err := repository.mapRow(row, "Create", &companyID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			slog.Info("company_repository.GetById: No result found for ID", "ID", companyID, "error", err.Error())
+			slog.Info("company_repository.Create: No result found for ID", "ID", companyID, "error", err.Error())
 			return nil, internalErrors.NewNotFoundError("ID: '" + companyID.String() + "'")
 		}
 		return nil, err

--- a/internal/services/company_service.go
+++ b/internal/services/company_service.go
@@ -1,0 +1,82 @@
+package services
+
+import (
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/repositories"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CompanyService struct {
+	companyRepository *repositories.CompanyRepository
+}
+
+func NewCompanyService(companyRepository *repositories.CompanyRepository) *CompanyService {
+	return &CompanyService{companyRepository: companyRepository}
+}
+
+// CreateCompany can return ConflictError, InternalServiceError, ValidationError
+func (companyService *CompanyService) CreateCompany(company *models.CreateCompany) (*models.Company, error) {
+	if company == nil {
+		slog.Error("company_service.CreateCompany: company is nil")
+		return nil, internalErrors.NewValidationError(nil, "CreateCompany is nil")
+	}
+
+	err := company.Validate()
+	if err != nil {
+		var companyId string
+		if company.ID != nil {
+			companyId = company.ID.String()
+		} else {
+			companyId = "[not set]"
+		}
+
+		slog.Info("company_service.CreateCompany: Company to create is invalid. ", "ID", companyId, "error", err)
+		return nil, err
+	}
+
+	if company.CreatedDate == nil {
+		createdDate := time.Now()
+		company.CreatedDate = &createdDate
+	} else if company.CreatedDate.IsZero() {
+		createdDate := time.Now()
+		company.CreatedDate = &createdDate
+		slog.Info("company_service.createCompany: company.CreatedDate is zero. Setting to '" + company.CreatedDate.String() + "'")
+	}
+
+	if company.LastContact != nil && company.LastContact.IsZero() {
+		company.LastContact = company.CreatedDate
+		slog.Info("company_service.createCompany: company.LastContact is zero. Setting to CreatedDate: '" + company.LastContact.String() + "'")
+	}
+
+	// can return ConflictError, InternalServiceError
+	insertedCompany, err := companyService.companyRepository.Create(company)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("CompanyService.CreateCompany: inserted company.", "company.ID", insertedCompany.ID.String())
+	return insertedCompany, nil
+}
+
+// GetCompanyById can return InternalServiceError, NotFoundError, ValidationError
+func (companyService *CompanyService) GetCompanyById(companyId *uuid.UUID) (*models.Company, error) {
+	if companyId == nil {
+		companyIdString := "company ID"
+		err := internalErrors.NewValidationError(&companyIdString, "companyId is required")
+		slog.Info("CompanyService.GetCompanyById: Failed to get company", "error", err)
+		return nil, err
+	}
+
+	// can return InternalServiceError, NotFoundError, ValidationError
+	company, err := companyService.companyRepository.GetById(companyId)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("CompanyService.GetCompanyById: Retrieved company.", "company.ID", company.ID.String())
+	return company, nil
+}

--- a/internal/services/company_service_integration_test.go
+++ b/internal/services/company_service_integration_test.go
@@ -1,0 +1,245 @@
+package services_test
+
+import (
+	"errors"
+	configPackage "jobsearchtracker/internal/config"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/services"
+	"jobsearchtracker/internal/testutil/dependencyinjection"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupCompanyService(t *testing.T) *services.CompanyService {
+	config := &configPackage.Config{
+		DatabaseMigrationsPath:               "../../migrations",
+		IsDatabaseMigrationsPathAbsolutePath: false,
+	}
+
+	container := dependencyinjection.SetupCompanyServiceTestContainer(t, *config)
+
+	var companyService *services.CompanyService
+	err := container.Invoke(func(companySvc *services.CompanyService) {
+		companyService = companySvc
+	})
+	assert.NoError(t, err)
+
+	return companyService
+}
+
+// -------- CreateCompany tests: --------
+
+func TestCreateCompany_ShouldWork(t *testing.T) {
+	companyService := setupCompanyService(t)
+
+	id := uuid.New()
+	notes := "some notes"
+	lastContact := time.Now().AddDate(-1, 0, 0)
+	createdDate := time.Now().AddDate(0, -5, 0)
+	updatedDate := time.Now().AddDate(0, 0, -3)
+
+	companyToInsert := models.CreateCompany{
+		ID:          &id,
+		Name:        "companyName",
+		CompanyType: models.CompanyTypeRecruiter,
+		Notes:       &notes,
+		LastContact: &lastContact,
+		CreatedDate: &createdDate,
+		UpdatedDate: &updatedDate,
+	}
+
+	insertedCompany, err := companyService.CreateCompany(&companyToInsert)
+	assert.Nil(t, err, "Failed to create company: '%s'", err)
+	assert.NotNil(t, insertedCompany, "CreateCompany should return a company")
+
+	assert.Equal(t, *companyToInsert.ID, id)
+	assert.Equal(t, companyToInsert.Name, insertedCompany.Name, "insertedCompany.Name should be the same as companyToInsert.Name")
+	assert.Equal(t, companyToInsert.CompanyType, insertedCompany.CompanyType, "insertedCompany.CompanyType should be the same as companyToInsert.CompanyType")
+	assert.Equal(t, companyToInsert.Notes, insertedCompany.Notes, "insertedCompany.Notes should be the same as companyToInsert.Notes")
+
+	insertedCompanyLastContact := insertedCompany.LastContact.Format(time.RFC3339)
+	companyToInsertLastContact := companyToInsert.LastContact.Format(time.RFC3339)
+	assert.Equal(t, companyToInsertLastContact, insertedCompanyLastContact, "insertedCompany.LastContact should be the same as companyToInsert.LastContact")
+
+	insertedCompanyCreatedDate := insertedCompany.CreatedDate.Format(time.RFC3339)
+	companyToInsertCreatedDate := companyToInsert.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, companyToInsertCreatedDate, insertedCompanyCreatedDate, "insertedCompany.CreatedDate should be the same as companyToInsert.CreatedDate")
+
+	insertedCompanyUpdatedDate := insertedCompany.UpdatedDate.Format(time.RFC3339)
+	companyToInsertUpdatedDate := companyToInsert.UpdatedDate.Format(time.RFC3339)
+	assert.Equal(t, companyToInsertUpdatedDate, insertedCompanyUpdatedDate, "insertedCompany.UpdatedDate should be the same as companyToInsert.UpdatedDate")
+}
+
+func TestCreateCompany_ShouldHandleEmptyFields(t *testing.T) {
+	companyService := setupCompanyService(t)
+
+	companyToInsert := models.CreateCompany{
+		Name:        "companyName",
+		CompanyType: models.CompanyTypeEmployer,
+	}
+
+	insertedDateApproximation := time.Now().Format(time.RFC3339)
+	insertedCompany, err := companyService.CreateCompany(&companyToInsert)
+
+	assert.Nil(t, err, "Failed to create company: '%s'", err)
+	assert.NotNil(t, insertedCompany, "CreateCompany should return a company")
+
+	assert.Equal(t, companyToInsert.Name, insertedCompany.Name, "insertedCompany.Name should be the same as company.Name")
+	assert.Equal(t, companyToInsert.CompanyType, insertedCompany.CompanyType, "insertedCompany.CompanyType should be the same as company.CompanyType")
+	assert.Nil(t, insertedCompany.Notes, "inserted company.Notes should be nil, but got '%s'", insertedCompany.Notes)
+	assert.Nil(t, insertedCompany.LastContact, "inserted company.LastContact should be nil, but got '%s'", insertedCompany.LastContact)
+
+	insertedCompanyCreatedDate := insertedCompany.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, insertedDateApproximation, insertedCompanyCreatedDate, "insertedCompany.CreatedDate should be the same as '%s'", insertedDateApproximation)
+
+	assert.Nil(t, insertedCompany.UpdatedDate, "inserted company.UpdatedDate should be nil, but got '%s'", insertedCompany.UpdatedDate)
+}
+
+func TestCreateCompany_ShouldHandleUnsetCreatedDate(t *testing.T) {
+	companyService := setupCompanyService(t)
+
+	companyToInsert := models.CreateCompany{
+		Name:        "companyName",
+		CompanyType: models.CompanyTypeEmployer,
+		CreatedDate: &time.Time{},
+	}
+
+	insertedDateApproximation := time.Now().Format(time.RFC3339)
+	insertedCompany, err := companyService.CreateCompany(&companyToInsert)
+
+	assert.Nil(t, err, "Failed to create company: '%s'", err)
+	assert.NotNil(t, insertedCompany, "CreateCompany should return a company")
+
+	assert.Equal(t, companyToInsert.Name, insertedCompany.Name, "insertedCompany.Name should be the same as company.Name")
+	assert.Equal(t, companyToInsert.CompanyType, insertedCompany.CompanyType, "insertedCompany.CompanyType should be the same as company.CompanyType")
+	assert.Nil(t, insertedCompany.Notes, "inserted company.Notes should be nil, but got '%s'", insertedCompany.Notes)
+	assert.Nil(t, insertedCompany.LastContact, "inserted company.LastContact should be nil, but got '%s'", insertedCompany.LastContact)
+
+	insertedCompanyCreatedDate := insertedCompany.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, insertedDateApproximation, insertedCompanyCreatedDate, "insertedCompany.CreatedDate should be the same as '%s'", insertedDateApproximation)
+
+	assert.Nil(t, insertedCompany.UpdatedDate, "inserted company.UpdatedDate should be nil, but got '%s'", insertedCompany.UpdatedDate)
+}
+
+func TestCreateCompany_ShouldSetUnsetLastContactToCreatedDate(t *testing.T) {
+	companyService := setupCompanyService(t)
+
+	createdDate := time.Now().AddDate(0, 0, -2)
+
+	companyToInsert := models.CreateCompany{
+		ID:          nil,
+		Name:        "companyName",
+		CompanyType: models.CompanyTypeEmployer,
+		Notes:       nil,
+		LastContact: &time.Time{},
+		CreatedDate: &createdDate,
+		UpdatedDate: nil,
+	}
+
+	insertedCompany, err := companyService.CreateCompany(&companyToInsert)
+
+	assert.Nil(t, err, "Failed to create company: '%s'", err)
+	assert.NotNil(t, insertedCompany, "CreateCompany should return a company")
+
+	assert.Equal(t, companyToInsert.Name, insertedCompany.Name, "insertedCompany.Name should be the same as company.Name")
+	assert.Equal(t, companyToInsert.CompanyType, insertedCompany.CompanyType, "insertedCompany.CompanyType should be the same as company.CompanyType")
+	assert.Nil(t, insertedCompany.Notes, "inserted company.Notes should be nil, but got '%s'", insertedCompany.Notes)
+
+	insertedCompanyCreatedDate := insertedCompany.CreatedDate.Format(time.RFC3339)
+	companyToInsertCreatedDate := companyToInsert.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, companyToInsertCreatedDate, insertedCompanyCreatedDate, "insertedCompany.CreatedDate should be the same as companyToInsert.CreatedDate")
+
+	insertedCompanyLastContact := insertedCompany.LastContact.Format(time.RFC3339)
+	assert.Equal(t, insertedCompanyCreatedDate, insertedCompanyLastContact, "insertedCompany.LastContact should be the same as companyToInsert.CreatedDate")
+
+	assert.Nil(t, insertedCompany.UpdatedDate, "inserted company.UpdatedDate should be nil, but got '%s'", insertedCompany.UpdatedDate)
+}
+
+// -------- GetCompanyById tests: --------
+
+func TestGetCompanyById_ShouldWork(t *testing.T) {
+	companyService := setupCompanyService(t)
+
+	id := uuid.New()
+	notes := "some notes"
+	lastContact := time.Now()
+	createdDate := time.Now().AddDate(0, -5, 0)
+	updatedDate := time.Now().AddDate(0, 0, 2)
+
+	companyToInsert := models.CreateCompany{
+		ID:          &id,
+		Name:        "companyName",
+		CompanyType: models.CompanyTypeRecruiter,
+		Notes:       &notes,
+		LastContact: &lastContact,
+		CreatedDate: &createdDate,
+		UpdatedDate: &updatedDate,
+	}
+
+	_, err := companyService.CreateCompany(&companyToInsert)
+	assert.Nil(t, err, "Failed to create company: '%s'", err)
+
+	retrievedCompany, err := companyService.GetCompanyById(&id)
+	assert.Nil(t, err, "Failed to create retrieve: '%s'", err)
+	assert.NotNil(t, retrievedCompany, "retrieved company is nil")
+
+	assert.Equal(t, *companyToInsert.ID, retrievedCompany.ID, "retrievedCompany.ID should match companyToInsert.ID")
+	assert.Equal(t, companyToInsert.Name, retrievedCompany.Name, "retrievedCompany.Name should match companyToInsert.Name")
+	assert.Equal(t, companyToInsert.CompanyType, retrievedCompany.CompanyType, "retrievedCompany.CompanyType should match companyToInsert.CompanyType")
+	assert.Equal(t, companyToInsert.Notes, retrievedCompany.Notes, "retrievedCompany.Notes should match companyToInsert.Notes")
+
+	retrievedCompanyLastContact := retrievedCompany.LastContact.Format(time.RFC3339)
+	companyToInsertLastContact := companyToInsert.LastContact.Format(time.RFC3339)
+	assert.Equal(t, companyToInsertLastContact, retrievedCompanyLastContact, "retrievedCompany.CreatedDate should be the same as companyToInsert.CreatedDate")
+
+	retrievedCompanyCreatedDate := retrievedCompany.CreatedDate.Format(time.RFC3339)
+	companyToInsertCreatedDate := companyToInsert.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, companyToInsertCreatedDate, retrievedCompanyCreatedDate, "retrievedCompany.CreatedDate should be the same as companyToInsert.CreatedDate")
+
+	retrievedCompanyUpdatedDate := retrievedCompany.UpdatedDate.Format(time.RFC3339)
+	companyToInsertUpdatedDate := companyToInsert.UpdatedDate.Format(time.RFC3339)
+	assert.Equal(t, companyToInsertUpdatedDate, retrievedCompanyUpdatedDate, "retrievedCompany.CreatedDate should be the same as companyToInsert.CreatedDate")
+}
+
+func TestGetCompanyById_ShouldReturnNotFoundErrorForAnIdThatDoesNotExist(t *testing.T) {
+	companyService := setupCompanyService(t)
+
+	nonExistingId := uuid.New()
+	retrievedCompany, err := companyService.GetCompanyById(&nonExistingId)
+	assert.NotNil(t, err, "Error should not be nil", err)
+	assert.Nil(t, retrievedCompany, "retrieved company should be nil")
+
+	var notFoundError *internalErrors.NotFoundError
+	assert.True(t, errors.As(err, &notFoundError))
+	assert.Equal(t, "error: object not found: ID: '"+nonExistingId.String()+"'", err.Error())
+
+	id := uuid.New()
+	notes := "some notes"
+	lastContact := time.Now()
+	createdDate := time.Now().AddDate(0, -5, 0)
+	updatedDate := time.Now().AddDate(0, 0, 2)
+
+	companyToInsert := models.CreateCompany{
+		ID:          &id,
+		Name:        "companyName",
+		CompanyType: models.CompanyTypeRecruiter,
+		Notes:       &notes,
+		LastContact: &lastContact,
+		CreatedDate: &createdDate,
+		UpdatedDate: &updatedDate,
+	}
+
+	_, err = companyService.CreateCompany(&companyToInsert)
+	assert.Nil(t, err, "Failed to create company: '%s'", err)
+
+	retrievedCompany, err = companyService.GetCompanyById(&nonExistingId)
+	assert.NotNil(t, err, "Error should not be nil", err)
+	assert.Nil(t, retrievedCompany, "retrieved company should be nil")
+
+	assert.True(t, errors.As(err, &notFoundError))
+	assert.Equal(t, "error: object not found: ID: '"+nonExistingId.String()+"'", err.Error())
+}

--- a/internal/services/company_service_test.go
+++ b/internal/services/company_service_test.go
@@ -1,0 +1,147 @@
+package services
+
+import (
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- CreateCompany tests: --------
+
+func TestCreateCompany_ShouldReturnValidationErrorOnNilCompany(t *testing.T) {
+	companyService := NewCompanyService(nil)
+
+	nilCompany, err := companyService.CreateCompany(nil)
+	assert.Nil(t, nilCompany, "company should be nil")
+	assert.NotNil(t, err, "error should not be nil")
+
+	var validationError *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationError))
+	assert.Equal(t, "validation error: CreateCompany is nil", err.Error())
+}
+
+func TestCreateCompany_ShouldReturnValidationErrorOnEmptyName(t *testing.T) {
+	companyService := NewCompanyService(nil)
+
+	id := uuid.New()
+	notes := "some notes"
+	lastContact := time.Now().AddDate(-1, 0, 0)
+	createdDate := time.Now().AddDate(0, -5, 0)
+	updatedDate := time.Now().AddDate(0, 0, -3)
+
+	company := &models.CreateCompany{
+		ID:          &id,
+		Name:        "",
+		CompanyType: models.CompanyTypeRecruiter,
+		Notes:       &notes,
+		LastContact: &lastContact,
+		CreatedDate: &createdDate,
+		UpdatedDate: &updatedDate,
+	}
+
+	nilCompany, err := companyService.CreateCompany(company)
+	assert.Nil(t, nilCompany, "company should be nil")
+	assert.NotNil(t, err, "error should not be nil")
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error on field 'Name': company name is empty", err.Error())
+}
+
+func TestCreateCompany_ShouldReturnValidationErrorOnEmptyCompanyType(t *testing.T) {
+	companyService := NewCompanyService(nil)
+
+	id := uuid.New()
+	notes := "More stuff"
+	lastContact := time.Now().AddDate(-1, 0, 0)
+	createdDate := time.Now().AddDate(0, -5, 0)
+	updatedDate := time.Now().AddDate(0, 0, -3)
+
+	company := &models.CreateCompany{
+		ID:          &id,
+		Name:        "A random person",
+		Notes:       &notes,
+		LastContact: &lastContact,
+		CreatedDate: &createdDate,
+		UpdatedDate: &updatedDate,
+	}
+
+	nilCompany, err := companyService.CreateCompany(company)
+	assert.Nil(t, nilCompany, "company should be nil")
+	assert.NotNil(t, err, "error should not be nil")
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error on field 'CompanyType': company type is invalid", err.Error())
+}
+
+func TestCreateCompany_ShouldReturnValidationErrorOnInvalidCompanyType(t *testing.T) {
+	companyService := NewCompanyService(nil)
+
+	id := uuid.New()
+	notes := "Noted"
+	lastContact := time.Now().AddDate(-1, 0, 0)
+	createdDate := time.Now().AddDate(0, -5, 0)
+	updatedDate := time.Now().AddDate(0, 0, -3)
+
+	company := &models.CreateCompany{
+		ID:          &id,
+		Name:        "Jan Janssen",
+		CompanyType: "Nothing",
+		Notes:       &notes,
+		LastContact: &lastContact,
+		CreatedDate: &createdDate,
+		UpdatedDate: &updatedDate,
+	}
+
+	nilCompany, err := companyService.CreateCompany(company)
+	assert.Nil(t, nilCompany, "company should be nil")
+	assert.NotNil(t, err, "error should not be nil")
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error on field 'CompanyType': company type is invalid", err.Error())
+}
+
+func TestCreateCompany_ShouldReturnValidationErrorOnUnsetUpdatedDate(t *testing.T) {
+	companyService := NewCompanyService(nil)
+
+	id := uuid.New()
+	notes := "some notes"
+	lastContact := time.Now().AddDate(-1, 0, 0)
+	createdDate := time.Now().AddDate(0, -5, 0)
+
+	company := &models.CreateCompany{
+		ID:          &id,
+		Name:        "Pick one",
+		CompanyType: models.CompanyTypeEmployer,
+		Notes:       &notes,
+		UpdatedDate: &time.Time{},
+		LastContact: &lastContact,
+		CreatedDate: &createdDate,
+	}
+
+	nilCompany, err := companyService.CreateCompany(company)
+	assert.Nil(t, nilCompany, "company should be nil")
+	assert.NotNil(t, err, "error should not be nil")
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error on field 'UpdatedDate': updated date is zero. It should either be 'nil' or a recent date. Given that this is an insert, it is recommended to use nil", err.Error())
+}
+
+// -------- GetCompanyById tests: --------
+
+func TestGetCompanyById_ShouldReturnValidationErrorIfCompanyIdIsNil(t *testing.T) {
+	companyService := NewCompanyService(nil)
+
+	company, err := companyService.GetCompanyById(nil)
+	assert.NotNil(t, err, "error should not be nil")
+	assert.Equal(t, "validation error on field 'company ID': companyId is required", err.Error())
+	assert.Nil(t, company, "company should be nil")
+}

--- a/internal/testutil/dependencyinjection/container.go
+++ b/internal/testutil/dependencyinjection/container.go
@@ -2,14 +2,16 @@ package dependencyinjection
 
 import (
 	"database/sql"
-	"go.uber.org/dig"
 	configPackage "jobsearchtracker/internal/config"
 	databasePackage "jobsearchtracker/internal/database"
 	"jobsearchtracker/internal/repositories"
+	"jobsearchtracker/internal/services"
 	"log"
 	"log/slog"
 	"os"
 	"testing"
+
+	"go.uber.org/dig"
 )
 
 func SetupDatabaseTestContainer(t *testing.T, config configPackage.Config) *dig.Container {
@@ -65,6 +67,19 @@ func SetupCompanyRepositoryTestContainer(t *testing.T, config configPackage.Conf
 	})
 	if err != nil {
 		log.Fatal("Failed to provide companyRepository", err)
+	}
+
+	return container
+}
+
+func SetupCompanyServiceTestContainer(t *testing.T, config configPackage.Config) *dig.Container {
+	container := SetupCompanyRepositoryTestContainer(t, config)
+
+	err := container.Provide(func(companyRepository *repositories.CompanyRepository) *services.CompanyService {
+		return services.NewCompanyService(companyRepository)
+	})
+	if err != nil {
+		log.Fatal("Failed to provide companyService", err)
 	}
 
 	return container


### PR DESCRIPTION
- Added `company_service` for creating a company and getting a company by ID.
- Added tests and integration tests for `company_service`.
- Added `SetupCompanyServiceTestContainer` to `container.go`.
- Fixed a log message typo in `company_repository`.