### PR TITLE
Add company handlers

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,6 +1,10 @@
 package api
 
 import (
+	"database/sql"
+	apiV1 "jobsearchtracker/internal/api/v1/handlers"
+	"jobsearchtracker/internal/repositories"
+	"jobsearchtracker/internal/services"
 	"log/slog"
 	"net/http"
 
@@ -12,10 +16,17 @@ type Server struct {
 	logger *slog.Logger
 }
 
-func NewServer(logger *slog.Logger) *Server {
+func NewServer(database *sql.DB, logger *slog.Logger) *Server {
 	slog.SetDefault(logger)
 
+	companyRepository := repositories.NewCompanyRepository(database)
+	companyService := services.NewCompanyService(companyRepository)
+	companyHandler := apiV1.NewCompanyHandler(companyService)
+
 	router := mux.NewRouter()
+
+	router.HandleFunc("/api/v1/company/new", companyHandler.CreateCompany).Methods(http.MethodPost)
+	router.HandleFunc("/api/v1/company/get/id/{id}", companyHandler.GetCompanyById).Methods(http.MethodGet)
 
 	logger.Info("Server created. Returning Server.")
 	return &Server{router: router, logger: logger}

--- a/internal/api/v1/handlers/company_handlers.go
+++ b/internal/api/v1/handlers/company_handlers.go
@@ -1,0 +1,165 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"jobsearchtracker/internal/api/v1/requests"
+	"jobsearchtracker/internal/api/v1/responses"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/services"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+type CompanyHandler struct {
+	companyService *services.CompanyService
+}
+
+func NewCompanyHandler(companyService *services.CompanyService) *CompanyHandler {
+	return &CompanyHandler{companyService: companyService}
+}
+
+func (companyHandler *CompanyHandler) CreateCompany(writer http.ResponseWriter, request *http.Request) {
+	var createCompanyRequest requests.CreateCompanyRequest
+	if err := json.NewDecoder(request.Body).Decode(&createCompanyRequest); err != nil {
+		slog.Info("v1.CompanyHandler.CreateCompany: invalid request body", "error", err)
+		http.Error(writer, "invalid request body: Unable to parse JSON", http.StatusBadRequest)
+		return
+	}
+
+	// can return ValidationError
+	createCompanyModel, err := createCompanyRequest.ToModel()
+	if err != nil {
+		slog.Info(
+			"v1.CompanyHandler.CreateCompany: Unable to convert CreateCompanyRequest to model",
+			"error", err)
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if createCompanyModel == nil {
+		slog.Error("v1.CompanyHandler.CreateCompany: createCompanyModel is nil", "error", err)
+		http.Error(writer,
+			"Unable to convert request to internal model: Internal model is nil",
+			http.StatusInternalServerError)
+		return
+	}
+
+	// can return ConflictError, InternalServiceError, ValidationError
+	createdCompany, err := companyHandler.companyService.CreateCompany(createCompanyModel)
+	if err != nil {
+		var conflictErr *internalErrors.ConflictError
+		var internalServiceErr *internalErrors.InternalServiceError
+		var validationErr *internalErrors.ValidationError
+
+		var errorMessage string
+		var status int
+
+		if errors.As(err, &conflictErr) {
+			errorMessage = "Conflict error on insert: ID already exists"
+			status = http.StatusConflict
+			slog.Info("v1.CompanyHandler.CreateCompany: ConflictError creating company", "error", err)
+		} else if errors.As(err, &internalServiceErr) {
+			errorMessage = "Internal service error while creating company"
+			status = http.StatusInternalServerError
+			slog.Error("v1.CompanyHandler.CreateCompany: "+errorMessage, "error", err)
+		} else if errors.As(err, &validationErr) {
+			errorMessage = err.Error()
+			status = http.StatusBadRequest
+			slog.Info("v1.CompanyHandler.CreateCompany: ValidationError while creating company", "error", err)
+		} else {
+			errorMessage = "Unknown internal error while creating company"
+			status = http.StatusInternalServerError
+			slog.Error("v1.CompanyHandler.CreateCompany: Error while creating company", "error", err)
+		}
+		http.Error(writer, errorMessage, status)
+		return
+	}
+
+	// can return InternalServiceError
+	companyResponse, err := responses.NewCompanyResponse(createdCompany)
+	if err != nil {
+		slog.Error("v1.CompanyHandler.CreateCompany: Unable to convert internal model to response", "error", err)
+		http.Error(writer, "Error: Unable to convert internal model to response", http.StatusInternalServerError)
+	}
+
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(http.StatusCreated)
+	err = json.NewEncoder(writer).Encode(companyResponse)
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		slog.Error("v1.CompanyHandler.CreateCompany: Unable to write response", "error", err)
+		http.Error(writer, "Company created but unable to create response", http.StatusInternalServerError)
+
+		return
+	}
+}
+
+func (companyHandler *CompanyHandler) GetCompanyById(writer http.ResponseWriter, request *http.Request) {
+	vars := mux.Vars(request)
+	companyIDStr := vars["id"]
+
+	if companyIDStr == "" {
+		slog.Info("v1.CompanyHandler.GetCompanyById: company ID is empty")
+		http.Error(writer, "company ID is empty", http.StatusBadRequest)
+		return
+	}
+
+	companyID, err := uuid.Parse(companyIDStr)
+	if err != nil {
+		slog.Info("v1.CompanyHandler.GetCompanyById: Company ID is not a valid UUID")
+		http.Error(writer, "company ID is not a valid UUID", http.StatusBadRequest)
+		return
+	}
+
+	var internalServiceError *internalErrors.InternalServiceError
+	var notFoundError *internalErrors.NotFoundError
+	var validationErr *internalErrors.ValidationError
+
+	// can return InternalServiceError, NotFoundError, ValidationError
+	company, err := companyHandler.companyService.GetCompanyById(&companyID)
+	if err != nil {
+		var errorMessage string
+		var status int
+
+		if errors.As(err, &internalServiceError) {
+			errorMessage = "Internal service error while retrieving company"
+			status = http.StatusInternalServerError
+			slog.Error("v1.CompanyHandler.GetCompanyById: "+errorMessage, "error", err)
+		} else if errors.As(err, &notFoundError) {
+			errorMessage = "Company not found"
+			status = http.StatusNotFound
+			slog.Info("v1.CompanyHandler.GetCompanyById: "+errorMessage, "error", err)
+		} else if errors.As(err, &validationErr) {
+			errorMessage = err.Error()
+			status = http.StatusBadRequest
+			slog.Info("v1.CompanyHandler.GetCompanyById: Validation error", "error", err)
+		}
+		http.Error(writer, errorMessage, status)
+
+		return
+	}
+
+	// can return InternalServiceError
+	companyResponse, err := responses.NewCompanyResponse(company)
+	if err != nil {
+		slog.Error("v1.CompanyHandler.GetCompanyById: Unable to convert internal model to response", "error", err)
+		http.Error(writer, "Error: Unable to convert internal model to response", http.StatusInternalServerError)
+	}
+
+	writer.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(writer).Encode(companyResponse)
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		slog.Error("v1.CompanyHandler.GetCompanyById: Unable to write response", "error", err)
+		http.Error(writer, "Company found but unable to build response", http.StatusInternalServerError)
+
+		return
+	}
+
+	slog.Info("v1.CompanyHandler.GetCompanyById: retrieved company successfully", "company.ID", company.ID.String())
+
+	return
+}

--- a/internal/api/v1/handlers/company_handlers_integration_test.go
+++ b/internal/api/v1/handlers/company_handlers_integration_test.go
@@ -1,0 +1,174 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"jobsearchtracker/internal/api/v1/handlers"
+	"jobsearchtracker/internal/api/v1/requests"
+	"jobsearchtracker/internal/api/v1/responses"
+	configPackage "jobsearchtracker/internal/config"
+	"jobsearchtracker/internal/testutil/dependencyinjection"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupCompanyHandler(t *testing.T) *handlers.CompanyHandler {
+	config := configPackage.Config{
+		DatabaseMigrationsPath:               "../../../../migrations",
+		IsDatabaseMigrationsPathAbsolutePath: false,
+	}
+
+	container := dependencyinjection.SetupCompanyHandlerTestContainer(t, config)
+
+	var companyHandler *handlers.CompanyHandler
+	err := container.Invoke(func(companyHand *handlers.CompanyHandler) {
+		companyHandler = companyHand
+	})
+	assert.NoError(t, err)
+
+	return companyHandler
+}
+
+// -------- CreateCompany tests: --------
+
+func TestCreateCompany_ShouldReturnCompany(t *testing.T) {
+	companyHandler := setupCompanyHandler(t)
+
+	id := uuid.New()
+	notes := "Not a lot of notes for this company"
+	lastContact := time.Now().AddDate(0, 0, -1)
+
+	requestBody := requests.CreateCompanyRequest{
+		ID:          &id,
+		Name:        "random company name",
+		CompanyType: requests.CompanyTypeConsultancy,
+		Notes:       &notes,
+		LastContact: &lastContact,
+	}
+
+	requestBytes, err := json.Marshal(requestBody)
+	assert.Nil(t, err, "Failed to marshal create company request")
+
+	request, err := http.NewRequest(http.MethodPost, "/api/v1/companies/new", bytes.NewBuffer(requestBytes))
+	assert.Nil(t, err, "Failed to create request")
+
+	responseRecorder := httptest.NewRecorder()
+
+	companyHandler.CreateCompany(responseRecorder, request)
+	assert.Equal(t, http.StatusCreated, responseRecorder.Code, "expected response code to be 201")
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString, "CreateCompany returned empty body")
+
+	var companyResponse responses.CompanyResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&companyResponse)
+	assert.Nil(t, err, "Failed to unmarshal create company response")
+
+	assert.Equal(t, *requestBody.ID, companyResponse.ID, "companyResponse.ID should be the same as requestBody.ID")
+	assert.Equal(t, requestBody.Name, companyResponse.Name, "companyResponse.Name should be the same as requestBody.Name")
+	assert.Equal(t, requestBody.CompanyType, companyResponse.CompanyType, "companyResponse.requestBodyType should be the same as requestBody.requestBodyType")
+	assert.Equal(t, requestBody.Notes, companyResponse.Notes, "companyResponse.Notes should be the same as requestBody.Notes")
+
+	companyResponseLastContact := companyResponse.LastContact.Format(time.RFC3339)
+	requestBodyToInsertLastContact := requestBody.LastContact.Format(time.RFC3339)
+	assert.Equal(t, requestBodyToInsertLastContact, companyResponseLastContact, "companyResponse.LastContact should be the same as requestBody.LastContact")
+
+	companyResponseCreatedDate := companyResponse.CreatedDate.Format(time.RFC3339)
+	now := time.Now().Format(time.RFC3339)
+	assert.Equal(t, now, companyResponseCreatedDate, "companyResponse.CreatedDate should be the same as now")
+
+	assert.Nil(t, companyResponse.UpdatedDate, "companyResponse.UpdatedDate should be nil")
+}
+
+func TestCreateCompany_ShouldWorkWithOnlyRequiredFields(t *testing.T) {
+	companyHandler := setupCompanyHandler(t)
+
+	requestBody := requests.CreateCompanyRequest{
+		Name:        "random company name",
+		CompanyType: requests.CompanyTypeRecruiter,
+	}
+
+	requestBytes, err := json.Marshal(requestBody)
+	assert.Nil(t, err, "Failed to marshal create company request")
+
+	request, err := http.NewRequest(http.MethodPost, "/api/v1/companies/new", bytes.NewBuffer(requestBytes))
+	assert.Nil(t, err, "Failed to create request")
+
+	responseRecorder := httptest.NewRecorder()
+
+	createdDateApproximation := time.Now().Format(time.RFC3339)
+	companyHandler.CreateCompany(responseRecorder, request)
+	assert.Equal(t, http.StatusCreated, responseRecorder.Code, "expected response code to be 201")
+
+	var responseBodyString = responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString, "CreateCompany returned empty body")
+
+	var companyResponse responses.CompanyResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&companyResponse)
+	assert.Nil(t, err, "Failed to unmarshal create company response")
+
+	assert.Equal(t, requestBody.Name, companyResponse.Name, "companyResponse.Name should be the same as requestBody.Name")
+	assert.Equal(t, requestBody.CompanyType, companyResponse.CompanyType, "companyResponse.requestBodyType should be the same as requestBody.requestBodyType")
+
+	assert.Nil(t, companyResponse.Notes, "inserted company.Notes should be nil, but got '%s'", companyResponse.Notes)
+	assert.Nil(t, companyResponse.LastContact, "inserted company.LastContact should be nil, but got '%s'", companyResponse.LastContact)
+
+	insertedCompanyCreatedDate := companyResponse.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, createdDateApproximation, insertedCompanyCreatedDate, "insertedCompany.CreatedDate should be the same as '%s'", createdDateApproximation)
+
+	assert.Nil(t, companyResponse.UpdatedDate, "companyResponse.UpdatedDate should be nil")
+}
+
+func TestCreateCompany_ShouldReturnStatusConflict_IfCompanyIDIsDuplicate(t *testing.T) {
+	companyHandler := setupCompanyHandler(t)
+
+	companyID := uuid.New()
+
+	firstRequestBody := requests.CreateCompanyRequest{
+		ID:          &companyID,
+		Name:        "First Company",
+		CompanyType: requests.CompanyTypeRecruiter,
+	}
+
+	firstRequestBytes, err := json.Marshal(firstRequestBody)
+	assert.Nil(t, err, "Failed to marshal create first company request")
+
+	firstRequest, err := http.NewRequest(http.MethodPost, "/api/v1/companies/new", bytes.NewBuffer(firstRequestBytes))
+	assert.Nil(t, err, "Failed to create second request")
+
+	firstResponseRecorder := httptest.NewRecorder()
+
+	companyHandler.CreateCompany(firstResponseRecorder, firstRequest)
+	assert.Equal(t, http.StatusCreated, firstResponseRecorder.Code, "expected response code to be 201")
+
+	var firstCompanyResponse responses.CompanyResponse
+	err = json.NewDecoder(firstResponseRecorder.Body).Decode(&firstCompanyResponse)
+	assert.Nil(t, err, "Failed to unmarshal first create company response")
+
+	assert.Equal(t, companyID, firstCompanyResponse.ID, "firstCompanyResponse.ID should be the same as companyID")
+
+	secondRequestBody := requests.CreateCompanyRequest{
+		ID:          &companyID,
+		Name:        "Second Company",
+		CompanyType: requests.CompanyTypeEmployer,
+	}
+
+	secondRequestBytes, err := json.Marshal(secondRequestBody)
+	assert.Nil(t, err, "Failed to marshal create second company request")
+
+	secondRequest, err := http.NewRequest(http.MethodPost, "/api/v1/companies/new", bytes.NewBuffer(secondRequestBytes))
+	assert.Nil(t, err, "Failed to create second request")
+
+	secondResponseRecorder := httptest.NewRecorder()
+
+	companyHandler.CreateCompany(secondResponseRecorder, secondRequest)
+	assert.Equal(t, http.StatusConflict, secondResponseRecorder.Code, "expected response code to be 400")
+
+	expectedError := "Conflict error on insert: ID already exists\n"
+	assert.Equal(t, expectedError, secondResponseRecorder.Body.String(), "secondCompanyResponse returned wrong error in body")
+}

--- a/internal/api/v1/handlers/company_handlers_test.go
+++ b/internal/api/v1/handlers/company_handlers_test.go
@@ -1,0 +1,130 @@
+package handlers_test
+
+import (
+	"bytes"
+	v1 "jobsearchtracker/internal/api/v1/handlers"
+	"jobsearchtracker/internal/testutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- CreateCompany tests: --------
+
+func TestCreateCompany_ShouldRespondWithBadRequestStatus(t *testing.T) {
+	tests := []struct {
+		testName             string
+		inputRequest         *string
+		expectedResponseCode int
+		expectedErrorMessage string
+	}{
+		{
+			testName:             "body is nil",
+			inputRequest:         nil,
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n"},
+		{
+			testName:             "body is empty",
+			inputRequest:         testutil.StringPtr(""),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n"},
+		{
+			testName:             "body does not match CreateCompanyRequest",
+			inputRequest:         testutil.StringPtr(`{"recruiter_name":"Mark Droog"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error on field 'Name': Name is empty\n"},
+		{
+			testName:             "body Name is missing",
+			inputRequest:         testutil.StringPtr(`{"company_type":"recruiter"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error on field 'Name': Name is empty\n"},
+		{
+			testName:             "body CompanyType is missing",
+			inputRequest:         testutil.StringPtr(`{"name":"random company name"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error on field 'CompanyType': CompanyType is invalid\n"},
+		{
+			testName:             "body CompanyType is invalid",
+			inputRequest:         testutil.StringPtr(`{"name":"random company name","company_type":"other"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error on field 'CompanyType': CompanyType is invalid\n"},
+		{
+			testName:             "body is invalid",
+			inputRequest:         testutil.StringPtr(`{"recruiter_name":"Mark Droog"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error on field 'Name': Name is empty\n"},
+		{
+			testName:             "malformed json",
+			inputRequest:         testutil.StringPtr(`"name":"random company name","company_type":"consultancy"`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n"},
+	}
+	for _, test := range tests {
+		companyHandler := v1.NewCompanyHandler(nil)
+		t.Run(test.testName, func(t *testing.T) {
+
+			var requestBody []byte
+			if test.inputRequest != nil {
+				requestBody = []byte(*test.inputRequest)
+			} else {
+				requestBody = nil
+			}
+
+			request, err := http.NewRequest(http.MethodPost, "/api/v1/company/new", bytes.NewBuffer(requestBody))
+			assert.NoError(t, err)
+
+			responseRecorder := httptest.NewRecorder()
+
+			companyHandler.CreateCompany(responseRecorder, request)
+			assert.Equal(t, test.expectedResponseCode, responseRecorder.Code, "CreateCompany returned wrong status code")
+
+			responseBodyString := responseRecorder.Body.String()
+			assert.Equal(t, test.expectedErrorMessage, responseBodyString, "Unexpected response body")
+		})
+	}
+}
+
+// -------- GetCompanyById tests: --------
+
+func TestGetCompanyById_ShouldReturnErrorIfIdIsEmpty(t *testing.T) {
+	companyHandler := v1.NewCompanyHandler(nil)
+
+	request, err := http.NewRequest(http.MethodGet, "/api/v1/company/get/id", nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	vars := map[string]string{
+		"id": "",
+	}
+	request = mux.SetURLVars(request, vars)
+
+	companyHandler.GetCompanyById(responseRecorder, request)
+	assert.Equal(t, http.StatusBadRequest, responseRecorder.Code, "GetCompanyById returned wrong status code")
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.Equal(t, "company ID is empty\n", responseBodyString, "CreateCompany returned wrong error message in body")
+}
+
+func TestGetCompanyById_ShouldReturnErrorIfIdIsNotUUID(t *testing.T) {
+	companyHandler := v1.NewCompanyHandler(nil)
+
+	request, err := http.NewRequest(http.MethodGet, "/api/v1/company/get/id", nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	vars := map[string]string{
+		"id": "ID GOES HERE",
+	}
+	request = mux.SetURLVars(request, vars)
+
+	companyHandler.GetCompanyById(responseRecorder, request)
+	assert.Equal(t, http.StatusBadRequest, responseRecorder.Code, "GetCompanyById returned wrong status code")
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.Equal(t, "company ID is not a valid UUID\n", responseBodyString, "CreateCompany returned wrong error message in body")
+}

--- a/internal/api/v1/requests/company_requests.go
+++ b/internal/api/v1/requests/company_requests.go
@@ -1,0 +1,138 @@
+package requests
+
+import (
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CreateCompanyRequest struct {
+	ID          *uuid.UUID  `json:"id,omitempty"`
+	Name        string      `json:"name"`
+	CompanyType CompanyType `json:"company_type"`
+	Notes       *string     `json:"notes,omitempty"`
+	LastContact *time.Time  `json:"last_contact,omitempty"`
+}
+
+// Validate can return ValidationError
+func (request *CreateCompanyRequest) Validate() error {
+	if request.ID != nil {
+		err := uuid.Validate(request.ID.String())
+		if err != nil {
+			message := "ID is invalid"
+			slog.Info("CreateCompanyRequest.validate failed: " + message)
+			return internalErrors.NewValidationError(nil, message)
+		} else if *request.ID == uuid.Nil {
+			message := "ID is empty"
+			slog.Info("CreateCompanyRequest.Validate: "+message, "ID", request.ID)
+			return internalErrors.NewValidationError(nil, message)
+		}
+	}
+
+	if request.Name == "" {
+		message := "Name is empty"
+		slog.Info("CreateCompanyRequest.validate failed: " + message)
+		name := "Name"
+		return internalErrors.NewValidationError(&name, message)
+
+	}
+	if !request.CompanyType.IsValid() {
+		message := "CompanyType is invalid"
+		slog.Info("CreateCompanyRequest.validate failed: " + message)
+		companyType := "CompanyType"
+		return internalErrors.NewValidationError(&companyType, message)
+	}
+
+	return nil
+}
+
+// ToModel can return ValidationError
+func (request *CreateCompanyRequest) ToModel() (*models.CreateCompany, error) {
+	err := request.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	companyType, _ := request.CompanyType.ToModel()
+
+	companyModel := models.CreateCompany{
+		ID:          request.ID,
+		Name:        request.Name,
+		CompanyType: companyType,
+		Notes:       request.Notes,
+		LastContact: request.LastContact,
+		CreatedDate: nil,
+		UpdatedDate: nil,
+	}
+
+	return &companyModel, nil
+}
+
+type CompanyType string
+
+const (
+	CompanyTypeEmployer    = "employer"
+	CompanyTypeRecruiter   = "recruiter"
+	CompanyTypeConsultancy = "consultancy"
+)
+
+func (companyType CompanyType) IsValid() bool {
+	switch companyType {
+	case CompanyTypeEmployer, CompanyTypeRecruiter, CompanyTypeConsultancy:
+		return true
+	}
+	return false
+}
+
+func (companyType CompanyType) String() string {
+	return string(companyType)
+}
+
+// ToModel can return ValidationError
+func (companyType CompanyType) ToModel() (models.CompanyType, error) {
+	switch companyType {
+	case CompanyTypeEmployer:
+		return models.CompanyTypeEmployer, nil
+	case CompanyTypeRecruiter:
+		return models.CompanyTypeRecruiter, nil
+	case CompanyTypeConsultancy:
+		return models.CompanyTypeConsultancy, nil
+	default:
+		slog.Info("v1.types.toModel: Invalid CompanyType: '" + companyType.String() + "'")
+		companyTypeString := "CompanyType"
+		return "", internalErrors.NewValidationError(
+			&companyTypeString,
+			"invalid CompanyType: '"+companyType.String()+"'")
+	}
+}
+
+// NewCompanyType can return InternalServerError
+func NewCompanyType(modelCompanyType *models.CompanyType) (CompanyType, error) {
+	if modelCompanyType == nil {
+		slog.Info("v1.types.NewCompanyType: modelCompanyType is nil")
+		return "",
+			internalErrors.NewInternalServiceError(
+				"Error trying to convert internal companyType to external CompanyType.")
+	}
+
+	switch *modelCompanyType {
+	case models.CompanyTypeEmployer:
+		return CompanyTypeEmployer, nil
+	case models.CompanyTypeRecruiter:
+		return CompanyTypeRecruiter, nil
+	case models.CompanyTypeConsultancy:
+		return CompanyTypeConsultancy, nil
+	default:
+		slog.Error("v1.types.NewCompanyType: Invalid modelCompanyType: '" + modelCompanyType.String() + "'")
+		return "",
+			internalErrors.NewInternalServiceError(
+				"Error converting internal CompanyType to external CompanyType: '" + modelCompanyType.String() + "'")
+	}
+}
+
+func (companyType CompanyType) ToPointer() *CompanyType {
+	return &companyType
+}

--- a/internal/api/v1/requests/company_requests_test.go
+++ b/internal/api/v1/requests/company_requests_test.go
@@ -1,0 +1,249 @@
+package requests
+
+import (
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- CreateCompanyRequest tests: --------
+
+func TestCreateCompanyRequestValidate_ShouldValidateRequest(t *testing.T) {
+	id := uuid.New()
+	notes := "No notes here!"
+	lastContact := time.Now().AddDate(0, 0, -3)
+
+	request := CreateCompanyRequest{
+		ID:          &id,
+		Name:        "A random company",
+		CompanyType: CompanyTypeEmployer,
+		Notes:       &notes,
+		LastContact: &lastContact,
+	}
+
+	err := request.Validate()
+	assert.NoError(t, err)
+}
+
+func TestCreateCompanyRequestValidate_ShouldReturnValidationError(t *testing.T) {
+	tests := []struct {
+		testName             string
+		companyName          string
+		companyType          CompanyType
+		expectedErrorMessage string
+	}{
+		{
+			"Empty Name",
+			"",
+			CompanyTypeRecruiter,
+			"validation error on field 'Name': Name is empty"},
+		{
+			"Empty CompanyType",
+			"John Smith",
+			"",
+			"validation error on field 'CompanyType': CompanyType is invalid"},
+		{
+			"Invalid CompanyType", "Jane Snow",
+			"Spammer",
+			"validation error on field 'CompanyType': CompanyType is invalid"},
+		{
+			"Empty Name and CompanyType", "",
+			"",
+			"validation error on field 'Name': Name is empty"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			id := uuid.New()
+			notes := "No notes here!"
+			lastContact := time.Now().AddDate(0, 0, -3)
+
+			request := CreateCompanyRequest{
+				ID:          &id,
+				Name:        test.companyName,
+				CompanyType: test.companyType,
+				Notes:       &notes,
+				LastContact: &lastContact,
+			}
+
+			err := request.Validate()
+			assert.NotNil(t, err, "err should not be nil")
+
+			var validationErr *internalErrors.ValidationError
+			assert.True(t, errors.As(err, &validationErr))
+
+			assert.Equal(t, test.expectedErrorMessage, err.Error())
+		})
+	}
+}
+
+func TestCreateCompanyRequestToModel_ShouldConvertToModel(t *testing.T) {
+	id := uuid.New()
+	notes := "No notes here!"
+	lastContact := time.Now().AddDate(0, 0, -3)
+
+	request := CreateCompanyRequest{
+		ID:          &id,
+		Name:        "A random company",
+		CompanyType: CompanyTypeEmployer,
+		Notes:       &notes,
+		LastContact: &lastContact,
+	}
+
+	model, err := request.ToModel()
+	assert.Nil(t, err, "Error on CreateCompanyRequest.ToModel(): '%s'.", err)
+	assert.NotNil(t, model, "model is nil")
+
+	assert.Equal(t, *request.ID, *model.ID, "model.ID should be the same as request.ID")
+	assert.Equal(t, request.Name, model.Name, "model.Name should be the same as request.Name")
+	assert.Equal(t, request.CompanyType.String(), model.CompanyType.String(), "model.CompanyType should be the same value as request.CompanyType")
+	assert.Equal(t, request.Notes, model.Notes, "model.Notes should be the same as request.Notes")
+
+	modelLastContact := model.LastContact.Format(time.RFC3339)
+	requestLastContact := request.LastContact.Format(time.RFC3339)
+	assert.Equal(t, requestLastContact, modelLastContact, "model.LastContact should be the same as request..LastContact")
+
+	assert.Nil(t, model.CreatedDate, "model.CreatedDate should be nil, but got '%s'", model.CreatedDate)
+	assert.Nil(t, model.UpdatedDate, "model.UpdatedDate should be nil, but got '%s'", model.UpdatedDate)
+}
+
+func TestCreateCompanyRequestToModel_ShouldConvertToModelWithNilValues(t *testing.T) {
+
+	request := CreateCompanyRequest{
+		Name:        "Another company",
+		CompanyType: CompanyTypeEmployer,
+	}
+
+	model, err := request.ToModel()
+	assert.Nil(t, err, "Error on CreateCompanyRequest.ToModel(): '%s'.", err)
+	assert.NotNil(t, model, "model is nil")
+
+	assert.Nil(t, model.ID, "Expected ID to be nil")
+	assert.Equal(t, request.Name, model.Name, "model.Name should be the same as request.Name")
+	assert.Equal(t, request.CompanyType.String(), model.CompanyType.String(), "model.CompanyType should be the same as request.CompanyType")
+	assert.Nil(t, model.Notes, "Expected Notes to be nil")
+	assert.Nil(t, model.ID, "Expected ID to be nil")
+	assert.Nil(t, model.LastContact, "model.LastContact should be nil, but got '%s'", model.LastContact)
+	assert.Nil(t, model.CreatedDate, "model.CreatedDate should be nil, but got '%s'", model.CreatedDate)
+	assert.Nil(t, model.UpdatedDate, "model.UpdatedDate should be nil, but got '%s'", model.UpdatedDate)
+}
+
+// -------- CompanyType tests: --------
+
+func TestCompanyTypeIsValid_ShouldReturnTrue(t *testing.T) {
+	employer := CompanyType(CompanyTypeEmployer)
+	assert.True(t, employer.IsValid())
+
+	recruiter := CompanyType(CompanyTypeRecruiter)
+	assert.True(t, recruiter.IsValid())
+
+	consultancy := CompanyType(CompanyTypeConsultancy)
+	assert.True(t, consultancy.IsValid())
+}
+
+func TestCompanyTypeIsValid_ShouldReturnFalseOnInvalidCompanyType(t *testing.T) {
+	empty := CompanyType("")
+	assert.False(t, empty.IsValid())
+
+	spammer := CompanyType("Spammer")
+	assert.False(t, spammer.IsValid())
+}
+
+func TestCompanyTypeToModel_ShouldConvertToModel(t *testing.T) {
+	employer := CompanyType(CompanyTypeEmployer)
+	modelEmployer, err := employer.ToModel()
+	assert.NoError(t, err)
+	assert.NotNil(t, modelEmployer)
+	assert.Equal(t, models.CompanyTypeEmployer, modelEmployer.String())
+
+	recruiter := CompanyType(CompanyTypeRecruiter)
+	modelRecruiter, err := recruiter.ToModel()
+	assert.NoError(t, err)
+	assert.NotNil(t, modelRecruiter)
+	assert.Equal(t, models.CompanyTypeRecruiter, modelRecruiter.String())
+
+	consultancy := CompanyType(CompanyTypeConsultancy)
+	modelConsultancy, err := consultancy.ToModel()
+	assert.NoError(t, err)
+	assert.NotNil(t, modelConsultancy)
+	assert.Equal(t, models.CompanyTypeConsultancy, modelConsultancy.String())
+}
+
+func TestCompanyTypeToModel_ShouldReturnValidationErrorOnInvalidCompanyType(t *testing.T) {
+	empty := CompanyType("")
+	emptyModel, err := empty.ToModel()
+	assert.NotNil(t, emptyModel)
+	assert.NotNil(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+
+	assert.Equal(t, "", emptyModel.String())
+	assert.Equal(t, "validation error on field 'CompanyType': invalid CompanyType: ''", err.Error())
+
+	scammer := CompanyType("scammer")
+	scammerModel, err := scammer.ToModel()
+	assert.NotNil(t, scammerModel)
+	assert.NotNil(t, err)
+
+	assert.True(t, errors.As(err, &validationErr))
+
+	assert.Equal(t, "", scammerModel.String())
+	assert.Equal(t, "validation error on field 'CompanyType': invalid CompanyType: 'scammer'", err.Error())
+}
+
+func TestNewCompanyType_ShouldConvertFromModel(t *testing.T) {
+	employer := models.CompanyType(models.CompanyTypeEmployer)
+	v1Employer, err := NewCompanyType(&employer)
+	assert.NoError(t, err)
+	assert.NotNil(t, v1Employer)
+
+	assert.Equal(t, CompanyTypeEmployer, v1Employer.String())
+
+	recruiter := models.CompanyType(models.CompanyTypeRecruiter)
+	v1Recruiter, err := NewCompanyType(&recruiter)
+	assert.NoError(t, err)
+	assert.NotNil(t, v1Recruiter)
+	assert.Equal(t, CompanyTypeRecruiter, v1Recruiter.String())
+
+	consultancy := models.CompanyType(models.CompanyTypeConsultancy)
+	v1Consultancy, err := NewCompanyType(&consultancy)
+	assert.NoError(t, err)
+	assert.NotNil(t, v1Consultancy)
+	assert.Equal(t, CompanyTypeConsultancy, v1Consultancy.String())
+}
+
+func TestNewCompanyType_ShouldReturnInternalServiceErrorOnNilCompanyType(t *testing.T) {
+	companyType, err := NewCompanyType(nil)
+	assert.NotNil(t, companyType)
+	assert.NotNil(t, err)
+
+	assert.Equal(t, "", companyType.String())
+	assert.Equal(t, "internal service error: Error trying to convert internal companyType to external CompanyType.", err.Error())
+}
+
+func TestNewCompanyType_ShouldReturnInternalServiceErrorOnInvalidCompanyType(t *testing.T) {
+	empty := models.CompanyType("")
+	emptyV1, err := NewCompanyType(&empty)
+	assert.NotNil(t, emptyV1)
+	assert.NotNil(t, err)
+	assert.Equal(t, "", emptyV1.String())
+
+	var internalServiceError *internalErrors.InternalServiceError
+	assert.True(t, errors.As(err, &internalServiceError))
+	assert.Equal(t, "internal service error: Error converting internal CompanyType to external CompanyType: ''", err.Error())
+
+	scammer := models.CompanyType("scammer")
+	scammerV1, err := NewCompanyType(&scammer)
+	assert.NotNil(t, scammerV1)
+	assert.NotNil(t, err)
+	assert.Equal(t, "", scammerV1.String())
+
+	assert.True(t, errors.As(err, &internalServiceError))
+	assert.Equal(t, "internal service error: Error converting internal CompanyType to external CompanyType: 'scammer'", err.Error())
+}

--- a/internal/api/v1/responses/company_responses.go
+++ b/internal/api/v1/responses/company_responses.go
@@ -1,0 +1,65 @@
+package responses
+
+import (
+	"jobsearchtracker/internal/api/v1/requests"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CompanyResponse struct {
+	ID          uuid.UUID            `json:"id"`
+	Name        string               `json:"name"`
+	CompanyType requests.CompanyType `json:"company_type"`
+	Notes       *string              `json:"notes"`
+	LastContact *time.Time           `json:"last_contact"`
+	CreatedDate time.Time            `json:"created_date"`
+	UpdatedDate *time.Time           `json:"updated_date"`
+}
+
+// NewCompanyResponse can return InternalServiceError
+func NewCompanyResponse(companyModel *models.Company) (*CompanyResponse, error) {
+	if companyModel == nil {
+		slog.Error("responses.NewCompanyResponse: Company is nil")
+		return nil, internalErrors.NewInternalServiceError("Error building response: Company is nil")
+	}
+
+	// can return InternalServerError
+	companyType, err := requests.NewCompanyType(&companyModel.CompanyType)
+	if err != nil {
+		return nil, err
+	}
+
+	companyResponse := CompanyResponse{
+		ID:          companyModel.ID,
+		Name:        companyModel.Name,
+		CompanyType: companyType,
+		Notes:       companyModel.Notes,
+		LastContact: companyModel.LastContact,
+		CreatedDate: companyModel.CreatedDate,
+		UpdatedDate: companyModel.UpdatedDate,
+	}
+
+	return &companyResponse, nil
+}
+
+// NewCompaniesResponse can return InternalServiceError
+func NewCompaniesResponse(companyModels []*models.Company) ([]*CompanyResponse, error) {
+	if companyModels == nil || len(companyModels) == 0 {
+		return []*CompanyResponse{}, nil
+	}
+
+	var companyResponses = make([]*CompanyResponse, len(companyModels))
+	for index := range companyModels {
+		companyResponse, err := NewCompanyResponse(companyModels[index])
+		if err != nil {
+			return nil, err
+		}
+		companyResponses[index] = companyResponse
+
+	}
+	return companyResponses, nil
+}

--- a/internal/api/v1/responses/company_responses_test.go
+++ b/internal/api/v1/responses/company_responses_test.go
@@ -1,0 +1,178 @@
+package responses
+
+import (
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- NewCompanyResponse tests: --------
+
+func TestNewCompanyResponse_ShouldWork(t *testing.T) {
+	notes := "some notes"
+	lastContact := time.Now().AddDate(0, 0, -3)
+	updatedDate := time.Now().AddDate(0, 0, -2)
+
+	model := models.Company{
+		ID:          uuid.New(),
+		Name:        "Randomized Company",
+		CompanyType: models.CompanyTypeEmployer,
+		Notes:       &notes,
+		LastContact: &lastContact,
+		CreatedDate: time.Now().AddDate(0, 0, -4),
+		UpdatedDate: &updatedDate,
+	}
+
+	response, err := NewCompanyResponse(&model)
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+
+	assert.Equal(t, model.ID, response.ID)
+	assert.Equal(t, model.Name, response.Name)
+	assert.Equal(t, model.CompanyType.String(), response.CompanyType.String())
+	assert.Equal(t, model.Notes, response.Notes)
+	assert.Equal(t, model.LastContact, response.LastContact)
+	assert.Equal(t, model.CreatedDate, response.CreatedDate)
+	assert.Equal(t, model.UpdatedDate, response.UpdatedDate)
+}
+
+func TestNewCompanyResponse_ShouldWorkWithOnlyRequiredFields(t *testing.T) {
+	model := models.Company{
+		ID:          uuid.New(),
+		Name:        "Yet another company name",
+		CompanyType: models.CompanyTypeConsultancy,
+		CreatedDate: time.Now().AddDate(0, 0, 1),
+	}
+
+	response, err := NewCompanyResponse(&model)
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+
+	assert.Equal(t, model.ID, response.ID)
+	assert.Equal(t, model.Name, response.Name)
+	assert.Equal(t, model.CompanyType.String(), response.CompanyType.String())
+	assert.Nil(t, response.Notes)
+	assert.Nil(t, response.LastContact)
+	assert.Equal(t, model.CreatedDate, response.CreatedDate)
+	assert.Nil(t, response.UpdatedDate)
+}
+
+func TestNewCompanyResponse_ShouldReturnInternalServiceErrorIfModelIsNil(t *testing.T) {
+	nilModel, err := NewCompanyResponse(nil)
+	assert.Nil(t, nilModel)
+	assert.NotNil(t, err)
+
+	var internalServiceErr *internalErrors.InternalServiceError
+	assert.True(t, errors.As(err, &internalServiceErr))
+
+	assert.Equal(t, "internal service error: Error building response: Company is nil", err.Error())
+}
+
+func TestNewCompanyResponse_ShouldReturnInternalServiceErrorIfCompanyTypeIsInvalid(t *testing.T) {
+	emptyCompanyType := models.Company{
+		ID:          uuid.New(),
+		Name:        "Randomized Company",
+		CompanyType: models.CompanyType(""),
+		CreatedDate: time.Now().AddDate(0, 0, 3),
+	}
+
+	emptyResponse, err := NewCompanyResponse(&emptyCompanyType)
+	assert.Nil(t, emptyResponse)
+	assert.NotNil(t, err)
+
+	var internalServiceErr *internalErrors.InternalServiceError
+	assert.True(t, errors.As(err, &internalServiceErr))
+
+	assert.Equal(t,
+		"internal service error: Error converting internal CompanyType to external CompanyType: ''",
+		err.Error())
+
+	badDataModel := models.Company{
+		ID:          uuid.New(),
+		Name:        "Randomized Company",
+		CompanyType: models.CompanyType("BadData"),
+		CreatedDate: time.Now().AddDate(0, 0, 3),
+	}
+
+	badDataResponse, err := NewCompanyResponse(&badDataModel)
+	assert.Nil(t, badDataResponse)
+	assert.NotNil(t, err)
+
+	assert.True(t, errors.As(err, &internalServiceErr))
+
+	assert.Equal(t,
+		"internal service error: Error converting internal CompanyType to external CompanyType: 'BadData'",
+		err.Error())
+}
+
+// -------- NewCompaniesResponse tests: --------
+
+func TestNewCompaniesResponse_ShouldWork(t *testing.T) {
+	companyModels := []*models.Company{
+		{
+			ID:          uuid.New(),
+			Name:        "CompanyOne",
+			CompanyType: models.CompanyTypeConsultancy,
+			CreatedDate: time.Now().AddDate(0, 0, -1),
+		},
+		{
+			ID:          uuid.New(),
+			Name:        "CompanyTwo",
+			CompanyType: models.CompanyTypeEmployer,
+			CreatedDate: time.Now().AddDate(0, 0, -2),
+		},
+	}
+
+	companies, err := NewCompaniesResponse(companyModels)
+	assert.NoError(t, err)
+	assert.NotNil(t, companies)
+	assert.Equal(t, len(companies), 2)
+}
+
+func TestNewCompaniesResponse_ShouldReturnEmptySliceIfModelIsNil(t *testing.T) {
+	response, err := NewCompaniesResponse(nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, 0, len(response))
+}
+
+func TestNewCompaniesResponse_ShouldReturnEmptySliceIfModelIsEmpty(t *testing.T) {
+	var companyModels []*models.Company
+	response, err := NewCompaniesResponse(companyModels)
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, 0, len(response))
+}
+
+func TestNewCompaniesResponse_ShouldReturnInternalServiceErrorIfOneCompanyTypeIsInvalid(t *testing.T) {
+	companyModels := []*models.Company{
+		{
+			ID:          uuid.New(),
+			Name:        "CompanyOne",
+			CompanyType: models.CompanyTypeEmployer,
+			CreatedDate: time.Now().AddDate(0, 0, 0),
+		},
+		{
+			ID:          uuid.New(),
+			Name:        "CompanyTwo",
+			CompanyType: "",
+			CreatedDate: time.Now().AddDate(0, 0, 0),
+		},
+	}
+
+	companies, err := NewCompaniesResponse(companyModels)
+	assert.Nil(t, companies)
+	assert.NotNil(t, err)
+
+	var internalServiceErr *internalErrors.InternalServiceError
+	assert.True(t, errors.As(err, &internalServiceErr))
+
+	assert.Equal(t,
+		"internal service error: Error converting internal CompanyType to external CompanyType: ''",
+		err.Error())
+}

--- a/internal/testutil/dependencyinjection/container.go
+++ b/internal/testutil/dependencyinjection/container.go
@@ -2,6 +2,7 @@ package dependencyinjection
 
 import (
 	"database/sql"
+	apiV1 "jobsearchtracker/internal/api/v1/handlers"
 	configPackage "jobsearchtracker/internal/config"
 	databasePackage "jobsearchtracker/internal/database"
 	"jobsearchtracker/internal/repositories"
@@ -80,6 +81,19 @@ func SetupCompanyServiceTestContainer(t *testing.T, config configPackage.Config)
 	})
 	if err != nil {
 		log.Fatal("Failed to provide companyService", err)
+	}
+
+	return container
+}
+
+func SetupCompanyHandlerTestContainer(t *testing.T, config configPackage.Config) *dig.Container {
+	container := SetupCompanyServiceTestContainer(t, config)
+
+	err := container.Provide(func(companyService *services.CompanyService) *apiV1.CompanyHandler {
+		return apiV1.NewCompanyHandler(companyService)
+	})
+	if err != nil {
+		log.Fatal("Failed to provide companyHandler", err)
 	}
 
 	return container

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -1,0 +1,5 @@
+package testutil
+
+func StringPtr(input string) *string {
+	return &input
+}


### PR DESCRIPTION
- Added handlers for `CreateCompany` and `GetCompanyById`.
- Added requests and responses for the above.
- Updated `server.go` to add above endpoints.
- Added test helper for converting a string to a pointer.