### PR TITLE
Propagate error back to the caller

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"go.uber.org/dig"
 	"jobsearchtracker/internal/api"
 	configPackage "jobsearchtracker/internal/config"
 	databasePackage "jobsearchtracker/internal/database"
@@ -15,6 +14,8 @@ import (
 	"os/signal"
 	"strconv"
 	"syscall"
+
+	"go.uber.org/dig"
 )
 
 func run() error {
@@ -95,7 +96,7 @@ func setupContainer() (*dig.Container, error) {
 }
 
 func startServer(server *api.Server, config *configPackage.Config) {
+	slog.Info("Starting server...", "port", config.ServerPort)
 
-	log.Printf("Server starting on port %d", config.ServerPort)
 	log.Fatal(http.ListenAndServe(":"+strconv.Itoa(config.ServerPort), server))
 }

--- a/main.go
+++ b/main.go
@@ -7,12 +7,10 @@ import (
 	"jobsearchtracker/internal/api"
 	configPackage "jobsearchtracker/internal/config"
 	databasePackage "jobsearchtracker/internal/database"
-	"log"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 
 	"go.uber.org/dig"
@@ -95,8 +93,7 @@ func setupContainer() (*dig.Container, error) {
 	return container, nil
 }
 
-func startServer(server *api.Server, config *configPackage.Config) {
+func startServer(server *api.Server, config *configPackage.Config) error {
 	slog.Info("Starting server...", "port", config.ServerPort)
-
-	log.Fatal(http.ListenAndServe(":"+strconv.Itoa(config.ServerPort), server))
+	return http.ListenAndServe(fmt.Sprintf(":%d", config.ServerPort), server)
 }

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func setupContainer() (*dig.Container, error) {
 		return nil, fmt.Errorf("failed to provide database: %w", err)
 	}
 
-	if err := container.Provide(api.NewServer); err != nil {
+	if err = container.Provide(api.NewServer); err != nil {
 		return nil, fmt.Errorf("failed to provide api server: %w", err)
 	}
 


### PR DESCRIPTION
This prevents `startServer` from failing immediately. Instead of calling `log.Fatal(http.ListenAndServe(...))`, we capture the error and propagate it back to the caller.

Result:
```
Connected to SQLite file database.
{"time":"2025-09-01T09:17:12.401447842-05:00","level":"INFO","msg":"Server created. Returning Server."}
{"time":"2025-09-01T09:17:12.401494725-05:00","level":"INFO","msg":"Starting server...","port":8080}
{"time":"2025-09-01T09:17:12.401656311-05:00","level":"ERROR","msg":"application failed to run","error":"failed to start server: listen tcp :8080: bind: address already in use"}

Process finished with the exit code 1
```