### PR TITLE
Add create Person and get Person by ID

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -23,6 +23,10 @@ func NewServer(database *sql.DB, logger *slog.Logger) *Server {
 	companyService := services.NewCompanyService(companyRepository)
 	companyHandler := apiV1.NewCompanyHandler(companyService)
 
+	personRepository := repositories.NewPersonRepository(database)
+	personService := services.NewPersonService(personRepository)
+	personHandler := apiV1.NewPersonHandler(personService)
+
 	router := mux.NewRouter()
 
 	router.HandleFunc("/api/v1/company/new", companyHandler.CreateCompany).Methods(http.MethodPost)
@@ -31,6 +35,9 @@ func NewServer(database *sql.DB, logger *slog.Logger) *Server {
 	router.HandleFunc("/api/v1/company/get/all", companyHandler.GetAllCompanies).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/company/update", companyHandler.UpdateCompany).Methods(http.MethodPost)
 	router.HandleFunc("/api/v1/company/delete/{id}", companyHandler.DeleteCompany).Methods(http.MethodDelete)
+
+	router.HandleFunc("/api/v1/person/new", personHandler.CreatePerson).Methods(http.MethodPost)
+	router.HandleFunc("/api/v1/person/get/id/{id}", personHandler.GetPersonByID).Methods(http.MethodGet)
 
 	logger.Info("Server created. Returning Server.")
 	return &Server{router: router, logger: logger}

--- a/internal/api/v1/handlers/person_handlers_integration_test.go
+++ b/internal/api/v1/handlers/person_handlers_integration_test.go
@@ -1,0 +1,239 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"jobsearchtracker/internal/api/v1/handlers"
+	"jobsearchtracker/internal/api/v1/requests"
+	"jobsearchtracker/internal/api/v1/responses"
+	configPackage "jobsearchtracker/internal/config"
+	"jobsearchtracker/internal/testutil/dependencyinjection"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupPersonHandler(t *testing.T) *handlers.PersonHandler {
+	config := configPackage.Config{
+		DatabaseMigrationsPath:               "../../../../migrations",
+		IsDatabaseMigrationsPathAbsolutePath: false,
+	}
+
+	container := dependencyinjection.SetupPersonHandlerTestContainer(t, config)
+
+	var personHandler *handlers.PersonHandler
+	err := container.Invoke(func(personHand *handlers.PersonHandler) {
+		personHandler = personHand
+	})
+	assert.NoError(t, err)
+
+	return personHandler
+}
+
+// -------- CreatePerson tests: --------
+
+func TestCreatePerson_ShouldInsertAndReturnPerson(t *testing.T) {
+	personHandler := setupPersonHandler(t)
+
+	id := uuid.New()
+	email := "e@ma.il"
+	phone := "456908"
+	notes := "Notes appeared here"
+	requestBody := requests.CreatePersonRequest{
+		ID:         &id,
+		Name:       "random person name",
+		PersonType: requests.PersonTypeHR,
+		Email:      &email,
+		Phone:      &phone,
+		Notes:      &notes,
+	}
+
+	requestBytes, err := json.Marshal(requestBody)
+	assert.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodPost, "/api/v1/person/new", bytes.NewBuffer(requestBytes))
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	createdDateApproximation := time.Now().Format(time.RFC3339)
+	personHandler.CreatePerson(responseRecorder, request)
+	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString)
+
+	var personResponse responses.PersonResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&personResponse)
+	assert.NoError(t, err)
+
+	assert.Equal(t, *requestBody.ID, personResponse.ID)
+	assert.Equal(t, requestBody.Name, personResponse.Name)
+	assert.Equal(t, requestBody.PersonType, personResponse.PersonType)
+	assert.Equal(t, requestBody.Email, personResponse.Email)
+	assert.Equal(t, requestBody.Phone, personResponse.Phone)
+	assert.Equal(t, requestBody.Notes, personResponse.Notes)
+
+	insertedPersonCreatedDate := personResponse.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, createdDateApproximation, insertedPersonCreatedDate)
+
+	assert.Nil(t, personResponse.UpdatedDate)
+}
+
+func TestCreatePerson_ShouldReturnStatusConflictIfPersonIDIsDuplicate(t *testing.T) {
+	personHandler := setupPersonHandler(t)
+
+	personID := uuid.New()
+
+	firstRequestBody := requests.CreatePersonRequest{
+		ID:         &personID,
+		Name:       "first Person Name",
+		PersonType: requests.PersonTypeOther,
+	}
+
+	firstRequestBytes, err := json.Marshal(firstRequestBody)
+	assert.NoError(t, err)
+
+	firstRequest, err := http.NewRequest(http.MethodPost, "/api/v1/person/new", bytes.NewBuffer(firstRequestBytes))
+	assert.NoError(t, err)
+
+	firstResponseRecorder := httptest.NewRecorder()
+
+	personHandler.CreatePerson(firstResponseRecorder, firstRequest)
+	assert.Equal(t, http.StatusCreated, firstResponseRecorder.Code)
+
+	var firstPersonResponse responses.PersonResponse
+	err = json.NewDecoder(firstResponseRecorder.Body).Decode(&firstPersonResponse)
+	assert.NoError(t, err)
+
+	assert.Equal(t, personID, firstPersonResponse.ID)
+
+	secondRequestBody := requests.CreatePersonRequest{
+		ID:         &personID,
+		Name:       "second Person Name",
+		PersonType: requests.PersonTypeCEO,
+	}
+
+	secondRequestBytes, err := json.Marshal(secondRequestBody)
+	assert.NoError(t, err)
+
+	secondRequest, err := http.NewRequest(http.MethodPost, "/api/v1/person/new", bytes.NewBuffer(secondRequestBytes))
+	assert.NoError(t, err)
+
+	secondResponseRecorder := httptest.NewRecorder()
+
+	personHandler.CreatePerson(secondResponseRecorder, secondRequest)
+	assert.Equal(t, http.StatusConflict, secondResponseRecorder.Code)
+
+	expectedError := "Conflict error on insert: ID already exists\n"
+	assert.Equal(t, expectedError, secondResponseRecorder.Body.String())
+}
+
+// -------- GetPersonById tests: --------
+
+func TestGetPersonById_ShouldReturnPerson(t *testing.T) {
+	personHandler := setupPersonHandler(t)
+
+	// insert a person:
+
+	id := uuid.New()
+	email := "Email here"
+	phone := "456908"
+	notes := "Notes appeared here"
+	requestBody := requests.CreatePersonRequest{
+		ID:         &id,
+		Name:       "random person name",
+		PersonType: requests.PersonTypeDeveloper,
+		Email:      &email,
+		Phone:      &phone,
+		Notes:      &notes,
+	}
+	_, createdDateApproximation := insertPerson(t, personHandler, requestBody)
+
+	// get the person:
+
+	getRequest, err := http.NewRequest(http.MethodGet, "/api/v1/person/get/id", nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	vars := map[string]string{
+		"id": id.String(),
+	}
+	getRequest = mux.SetURLVars(getRequest, vars)
+
+	personHandler.GetPersonByID(responseRecorder, getRequest)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString)
+
+	var response responses.PersonResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&response)
+	assert.NoError(t, err)
+
+	assert.Equal(t, *requestBody.ID, response.ID)
+	assert.Equal(t, requestBody.Name, response.Name)
+	assert.Equal(t, requestBody.PersonType, response.PersonType)
+	assert.Equal(t, requestBody.Email, response.Email)
+	assert.Equal(t, requestBody.Phone, response.Phone)
+	assert.Equal(t, requestBody.Notes, response.Notes)
+
+	insertedPersonCreatedDate := response.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, *createdDateApproximation, insertedPersonCreatedDate)
+
+	assert.Nil(t, response.UpdatedDate)
+}
+
+func TestGetPersonById_ShouldReturnNotFoundIfPersonDoesNotExist(t *testing.T) {
+	personHandler := setupPersonHandler(t)
+
+	request, err := http.NewRequest(http.MethodGet, "/api/v1/person/get/id", nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	vars := map[string]string{
+		"id": uuid.New().String(),
+	}
+	request = mux.SetURLVars(request, vars)
+
+	personHandler.GetPersonByID(responseRecorder, request)
+	assert.Equal(t, http.StatusNotFound, responseRecorder.Code)
+
+	firstResponseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, firstResponseBodyString, "Person not found\n")
+}
+
+// -------- Test helpers: --------
+
+func insertPerson(
+	t *testing.T, personHandler *handlers.PersonHandler, requestBody requests.CreatePersonRequest) (
+	*responses.PersonResponse, *string) {
+
+	requestBytes, err := json.Marshal(requestBody)
+	assert.NoError(t, err)
+
+	createRequest, err := http.NewRequest(http.MethodPost, "/api/v1/person/new", bytes.NewBuffer(requestBytes))
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	createdDateApproximation := time.Now().Format(time.RFC3339)
+	personHandler.CreatePerson(responseRecorder, createRequest)
+	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString)
+
+	var createPersonResponse responses.PersonResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&createPersonResponse)
+	assert.NoError(t, err)
+
+	return &createPersonResponse, &createdDateApproximation
+}

--- a/internal/api/v1/handlers/person_handlers_test.go
+++ b/internal/api/v1/handlers/person_handlers_test.go
@@ -1,0 +1,138 @@
+package handlers_test
+
+import (
+	"bytes"
+	v1 "jobsearchtracker/internal/api/v1/handlers"
+	"jobsearchtracker/internal/testutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- CreatePerson tests: --------
+
+func TestCreatePerson_ShouldRespondWithBadRequestStatus(t *testing.T) {
+	tests := []struct {
+		testName             string
+		inputRequest         *string
+		expectedResponseCode int
+		expectedErrorMessage string
+	}{
+		{
+			testName:             "body is nil",
+			inputRequest:         nil,
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n",
+		},
+		{
+			testName:             "body is empty",
+			inputRequest:         testutil.StringPtr(""),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n",
+		},
+		{
+			testName:             "body does not match CreatePersonRequest",
+			inputRequest:         testutil.StringPtr("{\"person_name\":\"test\"}"),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error on field 'Name': Name is empty\n",
+		},
+		{
+			testName:             "body Name is missing",
+			inputRequest:         testutil.StringPtr("{\"person_type\":\"CEO\"}"),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error on field 'Name': Name is empty\n",
+		},
+		{
+			testName:             "body PersonType is missing",
+			inputRequest:         testutil.StringPtr("{\"name\":\"test\"}"),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error on field 'PersonType': PersonType is invalid\n",
+		},
+		{
+			testName:             "body PersonType is invalid",
+			inputRequest:         testutil.StringPtr("{\"name\":\"test\", \"person_type\":\"Blah\"}"),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error on field 'PersonType': PersonType is invalid\n",
+		},
+		{
+			testName:             "body is invalid",
+			inputRequest:         testutil.StringPtr("{\"person_name\":\"test\"}"),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error on field 'Name': Name is empty\n",
+		},
+		{
+			testName:             "malformed json",
+			inputRequest:         testutil.StringPtr(`"name":"random name","person_type":"Other"`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n"},
+	}
+
+	for _, test := range tests {
+		personHandler := v1.NewPersonHandler(nil)
+		t.Run(test.testName, func(t *testing.T) {
+			var requestBody []byte
+			if test.inputRequest != nil {
+				requestBody = []byte(*test.inputRequest)
+			} else {
+				requestBody = nil
+			}
+
+			request, err := http.NewRequest(http.MethodPost, "/api/v1/person/new", bytes.NewBuffer(requestBody))
+			assert.NoError(t, err)
+
+			responseRecorder := httptest.NewRecorder()
+
+			personHandler.CreatePerson(responseRecorder, request)
+			assert.Equal(t, test.expectedResponseCode, responseRecorder.Code)
+
+			responseBodyString := responseRecorder.Body.String()
+			assert.Contains(t, responseBodyString, test.expectedErrorMessage)
+		})
+
+	}
+}
+
+// -------- GetPersonById tests: --------
+
+func TestGetPersonById_ShouldReturnErrorIfIdIsEmpty(t *testing.T) {
+	personHandler := v1.NewPersonHandler(nil)
+
+	request, err := http.NewRequest(http.MethodPost, "/api/v1/person/get/id", nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	vars := map[string]string{
+		"id": "",
+	}
+	request = mux.SetURLVars(request, vars)
+
+	personHandler.GetPersonByID(responseRecorder, request)
+	assert.Equal(t, http.StatusBadRequest, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.Equal(t, "person ID is empty\n", responseBodyString)
+}
+
+func TestGetPersonById_ShouldReturnErrorIfIdIsNotUUID(t *testing.T) {
+	personHandler := v1.NewPersonHandler(nil)
+
+	request, err := http.NewRequest(http.MethodPost, "/api/v1/person/get/id", nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	vars := map[string]string{
+		"id": "ID GOES HERE",
+	}
+	request = mux.SetURLVars(request, vars)
+
+	personHandler.GetPersonByID(responseRecorder, request)
+	assert.Equal(t, http.StatusBadRequest, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.Equal(t, "person ID is not a valid UUID\n", responseBodyString)
+}

--- a/internal/api/v1/requests/person_requests.go
+++ b/internal/api/v1/requests/person_requests.go
@@ -1,0 +1,168 @@
+package requests
+
+import (
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"log/slog"
+
+	"github.com/google/uuid"
+)
+
+type CreatePersonRequest struct {
+	ID         *uuid.UUID `json:"id,omitempty"`
+	Name       string     `json:"name"`
+	PersonType PersonType `json:"person_type"`
+	Email      *string    `json:"email,omitempty"`
+	Phone      *string    `json:"phone,omitempty"`
+	Notes      *string    `json:"notes,omitempty"`
+}
+
+func (request *CreatePersonRequest) validate() error {
+	if request.ID != nil {
+		err := uuid.Validate(request.ID.String())
+		if err != nil {
+			message := "ID is invalid"
+			slog.Info("CreatePersonRequest.validate failed: " + message)
+			return internalErrors.NewValidationError(nil, message)
+		} else if *request.ID == uuid.Nil {
+			message := "ID is empty"
+			slog.Info("CreatePersonRequest.Validate: "+message, "ID", request.ID)
+			return internalErrors.NewValidationError(nil, message)
+		}
+	}
+
+	if request.Name == "" {
+		message := "Name is empty"
+		slog.Info("CreatePersonRequest.validate failed: " + message)
+		name := "Name"
+		return internalErrors.NewValidationError(&name, message)
+	}
+
+	if !request.PersonType.IsValid() {
+		message := "PersonType is invalid"
+		slog.Info("CreatePersonRequest.validate failed: " + message)
+		companyType := "PersonType"
+		return internalErrors.NewValidationError(&companyType, message)
+	}
+
+	return nil
+}
+
+func (request *CreatePersonRequest) ToModel() (*models.CreatePerson, error) {
+	err := request.validate()
+	if err != nil {
+		return nil, err
+	}
+
+	personType, _ := request.PersonType.ToModel()
+
+	personModel := models.CreatePerson{
+		ID:          request.ID,
+		Name:        request.Name,
+		PersonType:  personType,
+		Email:       request.Email,
+		Phone:       request.Phone,
+		Notes:       request.Notes,
+		CreatedDate: nil,
+		UpdatedDate: nil,
+	}
+
+	return &personModel, nil
+}
+
+type PersonType string
+
+const (
+	PersonTypeCEO               = "CEO"
+	PersonTypeCTO               = "CTO"
+	PersonTypeDeveloper         = "developer"
+	PersonTypeExternalRecruiter = "externalRecruiter"
+	PersonTypeInternalRecruiter = "internalRecruiter"
+	PersonTypeHR                = "HR"
+	PersonTypeJobAdvertiser     = "jobAdvertiser"
+	PersonTypeJobContact        = "jobContact"
+	PersonTypeOther             = "other"
+	PersonTypeUnknown           = "unknown"
+)
+
+func (personType PersonType) IsValid() bool {
+	switch personType {
+	case PersonTypeCEO, PersonTypeCTO, PersonTypeDeveloper, PersonTypeExternalRecruiter, PersonTypeInternalRecruiter,
+		PersonTypeHR, PersonTypeJobAdvertiser, PersonTypeJobContact, PersonTypeOther, PersonTypeUnknown:
+		return true
+	}
+	return false
+}
+
+func (personType PersonType) String() string { return string(personType) }
+
+// ToModel can return ValidationError
+func (personType PersonType) ToModel() (models.PersonType, error) {
+	switch personType {
+	case PersonTypeCEO:
+		return models.PersonTypeCEO, nil
+	case PersonTypeCTO:
+		return models.PersonTypeCTO, nil
+	case PersonTypeDeveloper:
+		return models.PersonTypeDeveloper, nil
+	case PersonTypeExternalRecruiter:
+		return models.PersonTypeExternalRecruiter, nil
+	case PersonTypeInternalRecruiter:
+		return models.PersonTypeInternalRecruiter, nil
+	case PersonTypeHR:
+		return models.PersonTypeHR, nil
+	case PersonTypeJobAdvertiser:
+		return models.PersonTypeJobAdvertiser, nil
+	case PersonTypeJobContact:
+		return models.PersonTypeJobContact, nil
+	case PersonTypeOther:
+		return models.PersonTypeOther, nil
+	case PersonTypeUnknown:
+		return models.PersonTypeUnknown, nil
+	default:
+		slog.Info("v1.types.toModel: Invalid PersonType: '" + personType.String() + "'")
+		personTypeString := "PersonType"
+		return "", internalErrors.NewValidationError(
+			&personTypeString,
+			"invalid PersonType: '"+personType.String()+"'")
+	}
+}
+
+func NewPersonType(modelPersonType *models.PersonType) (PersonType, error) {
+	if modelPersonType == nil {
+		slog.Info("v1.types.NewPersonType: modelPersonType is nil")
+		return "", internalErrors.NewInternalServiceError(
+			"Error trying to convert internal personType to external PersonType.")
+	}
+
+	switch *modelPersonType {
+	case models.PersonTypeCEO:
+		return PersonTypeCEO, nil
+	case models.PersonTypeCTO:
+		return PersonTypeCTO, nil
+	case models.PersonTypeDeveloper:
+		return PersonTypeDeveloper, nil
+	case models.PersonTypeExternalRecruiter:
+		return PersonTypeExternalRecruiter, nil
+	case models.PersonTypeInternalRecruiter:
+		return PersonTypeInternalRecruiter, nil
+	case models.PersonTypeHR:
+		return PersonTypeHR, nil
+	case models.PersonTypeJobAdvertiser:
+		return PersonTypeJobAdvertiser, nil
+	case models.PersonTypeJobContact:
+		return PersonTypeJobContact, nil
+	case models.PersonTypeOther:
+		return PersonTypeOther, nil
+	case models.PersonTypeUnknown:
+		return PersonTypeUnknown, nil
+	default:
+		slog.Info("v1.types.NewPersonType: Invalid modelPersonType: '" + modelPersonType.String() + "'")
+		return "", internalErrors.NewInternalServiceError(
+			"Error converting internal PersonType to external PersonType: '" + modelPersonType.String() + "'")
+	}
+}
+
+func (personType PersonType) ToPointer() *PersonType {
+	return &personType
+}

--- a/internal/api/v1/requests/person_requests_test.go
+++ b/internal/api/v1/requests/person_requests_test.go
@@ -1,0 +1,125 @@
+package requests
+
+import (
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- CreatePersonRequest tests: --------
+
+func TestCreatePersonRequestValidate_ShouldValidateRequest(t *testing.T) {
+	id := uuid.New()
+	email := "no email here"
+	phone := "6839023748"
+	notes := "Something not noteworthy"
+
+	request := CreatePersonRequest{
+		ID:         &id,
+		Name:       "Nameless",
+		PersonType: PersonTypeDeveloper,
+		Email:      &email,
+		Phone:      &phone,
+		Notes:      &notes,
+	}
+
+	err := request.validate()
+	assert.NoError(t, err)
+}
+
+func TestCreatePersonRequestValidate_ShouldReturnValidationErrors(t *testing.T) {
+	tests := []struct {
+		testName             string
+		name                 string
+		personType           PersonType
+		expectedErrorMessage string
+	}{
+		{
+			"Empty Name",
+			"",
+			PersonTypeCTO,
+			"validation error on field 'Name': Name is empty"},
+		{
+			"Empty PersonType",
+			"Name present",
+			"",
+			"validation error on field 'PersonType': PersonType is invalid"},
+		{
+			"Invalid PersonType",
+			"Name present",
+			"Invalid PersonType",
+			"validation error on field 'PersonType': PersonType is invalid"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			email := "name@domain.tld"
+			notes := "Lots of text"
+			phone := "345023485"
+
+			request := CreatePersonRequest{
+				Name:       test.name,
+				PersonType: test.personType,
+				Email:      &email,
+				Phone:      &phone,
+				Notes:      &notes,
+			}
+
+			err := request.validate()
+			assert.NotNil(t, err)
+
+			var validationErr *internalErrors.ValidationError
+			assert.True(t, errors.As(err, &validationErr))
+
+			assert.Equal(t, test.expectedErrorMessage, err.Error())
+		})
+	}
+}
+
+func TestCreatePersonRequestToModel_ShouldConvertToModel(t *testing.T) {
+	id := uuid.New()
+	email := "email@email.email"
+	phone := "34543534"
+	notes := "Blah Blah"
+
+	request := CreatePersonRequest{
+		ID:         &id,
+		Name:       "Jane Doe",
+		PersonType: PersonTypeCEO,
+		Email:      &email,
+		Phone:      &phone,
+		Notes:      &notes,
+	}
+
+	model, err := request.ToModel()
+	assert.NoError(t, err)
+	assert.NotNil(t, model)
+
+	assert.Equal(t, id.String(), model.ID.String())
+	assert.Equal(t, request.Name, model.Name)
+	assert.Equal(t, request.PersonType.String(), model.PersonType.String())
+	assert.Equal(t, &email, model.Email)
+	assert.Equal(t, &phone, model.Phone)
+	assert.Equal(t, &notes, model.Notes)
+}
+
+func TestCreatePersonRequestToModel_ShouldConvertToModelWithNilValues(t *testing.T) {
+	request := CreatePersonRequest{
+		Name:       "Jane Doe",
+		PersonType: PersonTypeCEO,
+	}
+
+	model, err := request.ToModel()
+	assert.NoError(t, err)
+	assert.NotNil(t, model)
+
+	assert.Nil(t, model.ID)
+	assert.Equal(t, request.Name, model.Name)
+	assert.Equal(t, request.PersonType.String(), model.PersonType.String())
+	assert.Nil(t, model.Email)
+	assert.Nil(t, model.Phone)
+	assert.Nil(t, model.Notes)
+}

--- a/internal/api/v1/responses/person_responses.go
+++ b/internal/api/v1/responses/person_responses.go
@@ -1,0 +1,48 @@
+package responses
+
+import (
+	"jobsearchtracker/internal/api/v1/requests"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type PersonResponse struct {
+	ID          uuid.UUID           `json:"id"`
+	Name        string              `json:"name"`
+	PersonType  requests.PersonType `json:"person_type"`
+	Email       *string             `json:"email"`
+	Phone       *string             `json:"phone"`
+	Notes       *string             `json:"notes"`
+	CreatedDate time.Time           `json:"created_date"`
+	UpdatedDate *time.Time          `json:"updated_date"`
+}
+
+// NewPersonResponse can return InternalServerError
+func NewPersonResponse(personModel *models.Person) (*PersonResponse, error) {
+	if personModel == nil {
+		slog.Error("responses.NewPersonResponse: Person is nil")
+		return nil, internalErrors.NewInternalServiceError("Error building response: Person is nil")
+	}
+
+	personType, err := requests.NewPersonType(&personModel.PersonType)
+	if err != nil {
+		return nil, err
+	}
+
+	personResponse := PersonResponse{
+		ID:          personModel.ID,
+		Name:        personModel.Name,
+		PersonType:  personType,
+		Email:       personModel.Email,
+		Phone:       personModel.Phone,
+		Notes:       personModel.Notes,
+		CreatedDate: personModel.CreatedDate,
+		UpdatedDate: personModel.UpdatedDate,
+	}
+
+	return &personResponse, nil
+}

--- a/internal/api/v1/responses/person_responses_test.go
+++ b/internal/api/v1/responses/person_responses_test.go
@@ -1,0 +1,115 @@
+package responses
+
+import (
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- NewPersonResponse tests: --------
+
+func TestNewPersonResponse_ShouldWork(t *testing.T) {
+	email := "e@m.ai"
+	phone := "2345"
+	notes := "sdfgkljherwkl"
+	updatedDate := time.Now().AddDate(0, 0, 27)
+
+	model := models.Person{
+		ID:          uuid.New(),
+		Name:        "Blah blah",
+		PersonType:  models.PersonTypeJobContact,
+		Email:       &email,
+		Phone:       &phone,
+		Notes:       &notes,
+		CreatedDate: time.Now().AddDate(0, -1, 0),
+		UpdatedDate: &updatedDate,
+	}
+
+	response, err := NewPersonResponse(&model)
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+
+	assert.Equal(t, model.ID.String(), response.ID.String())
+	assert.Equal(t, model.Name, response.Name)
+	assert.Equal(t, model.PersonType.String(), response.PersonType.String())
+	assert.Equal(t, model.Email, response.Email)
+	assert.Equal(t, model.Phone, response.Phone)
+	assert.Equal(t, model.Notes, response.Notes)
+	assert.Equal(t, model.CreatedDate, response.CreatedDate)
+	assert.Equal(t, model.UpdatedDate, response.UpdatedDate)
+}
+
+func TestNewPersonResponse_ShouldWorkWithOnlyRequiredFields(t *testing.T) {
+	model := models.Person{
+		ID:          uuid.New(),
+		Name:        "Anker",
+		PersonType:  models.PersonTypeUnknown,
+		CreatedDate: time.Now().AddDate(0, 3, 0),
+	}
+
+	response, err := NewPersonResponse(&model)
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+
+	assert.Equal(t, model.ID.String(), response.ID.String())
+	assert.Equal(t, model.Name, response.Name)
+	assert.Equal(t, model.PersonType.String(), response.PersonType.String())
+	assert.Nil(t, response.Email)
+	assert.Nil(t, response.Phone)
+	assert.Nil(t, response.Notes)
+	assert.Equal(t, model.CreatedDate, response.CreatedDate)
+	assert.Nil(t, response.UpdatedDate)
+}
+
+func TestNewPersonResponse_ShouldReturnInternalServiceErrorIfModelIsNil(t *testing.T) {
+	nilModel, err := NewPersonResponse(nil)
+	assert.Nil(t, nilModel)
+	assert.NotNil(t, err)
+
+	var internalServiceErr *internalErrors.InternalServiceError
+	assert.True(t, errors.As(err, &internalServiceErr))
+
+	assert.Equal(t, err.Error(), "internal service error: Error building response: Person is nil")
+}
+
+func TestNewPersonResponse_ShouldReturnInternalServiceErrorIfCompanyTypeIsInvalid(t *testing.T) {
+	emptyPersonType := models.Person{
+		ID:          uuid.New(),
+		Name:        "Dave",
+		PersonType:  "",
+		CreatedDate: time.Now().AddDate(0, 0, 16),
+	}
+	emptyResponse, err := NewPersonResponse(&emptyPersonType)
+	assert.Nil(t, emptyResponse)
+	assert.NotNil(t, err)
+
+	var internalServiceErr *internalErrors.InternalServiceError
+	assert.True(t, errors.As(err, &internalServiceErr))
+
+	assert.Equal(
+		t,
+		"internal service error: Error converting internal PersonType to external PersonType: ''",
+		err.Error())
+
+	invalidPersonType := models.Person{
+		ID:          uuid.New(),
+		Name:        "Dave",
+		PersonType:  "Blah",
+		CreatedDate: time.Now().AddDate(0, 0, 16),
+	}
+	invalidResponse, err := NewPersonResponse(&invalidPersonType)
+	assert.Nil(t, invalidResponse)
+	assert.NotNil(t, err)
+
+	assert.True(t, errors.As(err, &internalServiceErr))
+
+	assert.Equal(
+		t,
+		"internal service error: Error converting internal PersonType to external PersonType: 'Blah'",
+		err.Error())
+}

--- a/internal/models/person.go
+++ b/internal/models/person.go
@@ -1,0 +1,92 @@
+package models
+
+import (
+	"jobsearchtracker/internal/errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Person struct {
+	ID          uuid.UUID
+	Name        string
+	PersonType  PersonType
+	Email       *string
+	Phone       *string
+	Notes       *string
+	CreatedDate time.Time
+	UpdatedDate *time.Time
+}
+
+type CreatePerson struct {
+	ID          *uuid.UUID
+	Name        string
+	PersonType  PersonType
+	Email       *string
+	Phone       *string
+	Notes       *string
+	CreatedDate *time.Time
+	UpdatedDate *time.Time
+}
+
+// Validate can return NewValidationError
+func (person *CreatePerson) Validate() error {
+	emptyString := ""
+
+	if person.Name == "" {
+		name := "Name"
+		return errors.NewValidationError(&name, "person name is empty")
+	}
+
+	if !person.PersonType.IsValid() {
+		companyType := "PersonType"
+		return errors.NewValidationError(&companyType, "person type is invalid")
+	}
+
+	if person.Email != nil && *person.Email == emptyString {
+		name := "email"
+		return errors.NewValidationError(&name, "person email is empty")
+	}
+
+	if person.Phone != nil && *person.Phone == emptyString {
+		name := "phone"
+		return errors.NewValidationError(
+			&name,
+			"person phone is empty. It should either be nil or a valid phone number")
+	}
+
+	if person.UpdatedDate != nil && person.UpdatedDate.IsZero() {
+		updatedDate := "UpdatedDate"
+		return errors.NewValidationError(
+			&updatedDate,
+			"updated date is zero. It should either be 'nil' or a recent date. Given that this is an insert, it is recommended to use nil")
+	}
+
+	return nil
+}
+
+type PersonType string
+
+const (
+	PersonTypeCEO               = "CEO"
+	PersonTypeCTO               = "CTO"
+	PersonTypeDeveloper         = "developer"
+	PersonTypeExternalRecruiter = "externalRecruiter"
+	PersonTypeInternalRecruiter = "internalRecruiter"
+	PersonTypeHR                = "HR"
+	PersonTypeJobAdvertiser     = "jobAdvertiser"
+	PersonTypeJobContact        = "jobContact"
+	PersonTypeOther             = "other"
+	PersonTypeUnknown           = "unknown"
+)
+
+func (personType PersonType) IsValid() bool {
+	switch personType {
+	case PersonTypeCEO, PersonTypeCTO, PersonTypeDeveloper, PersonTypeExternalRecruiter, PersonTypeInternalRecruiter,
+		PersonTypeHR, PersonTypeJobAdvertiser, PersonTypeJobContact, PersonTypeOther, PersonTypeUnknown:
+		return true
+	}
+	return false
+}
+
+func (personType PersonType) String() string { return string(personType) }

--- a/internal/models/person_test.go
+++ b/internal/models/person_test.go
@@ -1,0 +1,132 @@
+package models
+
+import (
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- CreatePerson.Validate tests: --------
+
+func TestCreatePersonValidate_ShouldReturnNilIfPersonIsValid(t *testing.T) {
+	id := uuid.New()
+	email := "Email Address"
+	phone := "84323445"
+	notes := "Noted"
+	createdDate := time.Now().AddDate(0, 0, 2)
+	updatedDate := time.Now().AddDate(0, 1, 0)
+
+	person := CreatePerson{
+		ID:          &id,
+		Name:        "Random Name",
+		PersonType:  PersonTypeOther,
+		Email:       &email,
+		Phone:       &phone,
+		Notes:       &notes,
+		CreatedDate: &createdDate,
+		UpdatedDate: &updatedDate,
+	}
+
+	err := person.Validate()
+	assert.NoError(t, err)
+}
+
+func TestCreatePersonValidate_ShouldReturnNilIfOnlyRequiredFieldsExist(t *testing.T) {
+
+	person := CreatePerson{
+		Name:       "Name Names",
+		PersonType: PersonTypeCEO,
+	}
+	err := person.Validate()
+	assert.NoError(t, err)
+}
+
+func TestCreatePersonValidate_ShouldReturnValidationErrorOnEmptyName(t *testing.T) {
+
+	person := CreatePerson{
+		Name:       "",
+		PersonType: PersonTypeUnknown,
+	}
+	err := person.Validate()
+	assert.NotNil(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error on field 'Name': person name is empty", validationErr.Error())
+}
+
+func TestCreatePersonValidate_ShouldReturnValidationErrorOnEmptyPersonType(t *testing.T) {
+	person := CreatePerson{
+		Name: "Name Names",
+	}
+	err := person.Validate()
+	assert.NotNil(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error on field 'PersonType': person type is invalid", validationErr.Error())
+}
+
+func TestCreatePersonValidate_ShouldReturnValidationErrorOnUnsetUpdatedDate(t *testing.T) {
+
+	person := CreatePerson{
+		PersonType:  PersonTypeJobAdvertiser,
+		Name:        "Something here",
+		UpdatedDate: &time.Time{},
+	}
+	err := person.Validate()
+	assert.NotNil(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t,
+		"validation error on field 'UpdatedDate': updated date is zero. It should either be 'nil' or a recent date. Given that this is an insert, it is recommended to use nil",
+		validationErr.Error())
+}
+
+// -------- PersonType.IsValid tests: --------
+
+func TestPersonTypeIsValid_ShouldReturnTrue(t *testing.T) {
+	ceo := PersonType(PersonTypeCEO)
+	assert.True(t, ceo.IsValid())
+
+	cto := PersonType(PersonTypeCTO)
+	assert.True(t, cto.IsValid())
+
+	developer := PersonType(PersonTypeDeveloper)
+	assert.True(t, developer.IsValid())
+
+	externalRecruiter := PersonType(PersonTypeExternalRecruiter)
+	assert.True(t, externalRecruiter.IsValid())
+
+	internalRecruiter := PersonType(PersonTypeInternalRecruiter)
+	assert.True(t, internalRecruiter.IsValid())
+
+	hr := PersonType(PersonTypeHR)
+	assert.True(t, hr.IsValid())
+
+	jobAdvertiser := PersonType(PersonTypeJobAdvertiser)
+	assert.True(t, jobAdvertiser.IsValid())
+
+	jobContact := PersonType(PersonTypeJobContact)
+	assert.True(t, jobContact.IsValid())
+
+	other := PersonType(PersonTypeOther)
+	assert.True(t, other.IsValid())
+
+	unknown := PersonType(PersonTypeUnknown)
+	assert.True(t, unknown.IsValid())
+
+}
+
+func TestPersonType_IsValid_ShouldReturnFalseOnInvalidCompanyType(t *testing.T) {
+	empty := PersonType("")
+	assert.False(t, empty.IsValid())
+
+	spammer := PersonType("MisTyped")
+	assert.False(t, spammer.IsValid())
+}

--- a/internal/repositories/person_repository.go
+++ b/internal/repositories/person_repository.go
@@ -1,0 +1,158 @@
+package repositories
+
+import (
+	"database/sql"
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type PersonRepository struct {
+	database *sql.DB
+}
+
+func NewPersonRepository(database *sql.DB) *PersonRepository {
+	return &PersonRepository{database: database}
+}
+
+// Create can return ConflictError, InternalServiceError
+func (repository *PersonRepository) Create(person *models.CreatePerson) (*models.Person, error) {
+	sqlInsert :=
+		"INSERT INTO person (id, name, person_type, email, phone, notes, created_date, updated_date) " +
+			"VALUES (?, ?, ?, ?, ?, ?, ?, ?) " +
+			"RETURNING id, name, person_type, email, phone, notes, created_date, updated_date"
+
+	var personID uuid.UUID
+	if person.ID != nil {
+		personID = *person.ID
+	} else {
+		personID = uuid.New()
+	}
+
+	var createdDate, updatedDate interface{}
+
+	if person.CreatedDate != nil {
+		createdDate = person.CreatedDate.Format(time.RFC3339)
+	} else {
+		createdDate = time.Now()
+	}
+
+	if person.UpdatedDate != nil {
+		updatedDate = person.UpdatedDate.Format(time.RFC3339)
+	}
+
+	row := repository.database.QueryRow(
+		sqlInsert,
+		personID,
+		person.Name,
+		person.PersonType,
+		person.Email,
+		person.Phone,
+		person.Notes,
+		createdDate,
+		updatedDate,
+	)
+
+	// can return ConflictError, InternalServiceError
+	result, err := repository.mapRow(row, "Create", &personID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			slog.Info("person_repository.create: No result found for ID", "ID", personID, "error", err.Error())
+			return nil, internalErrors.NewNotFoundError("ID: '" + personID.String() + "'")
+		}
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetById can return InternalServiceError, NotFoundError, ValidationError
+func (repository *PersonRepository) GetById(id *uuid.UUID) (*models.Person, error) {
+	if id == nil {
+		slog.Info("person_repository.GetById: ID is nil")
+		var id = "ID"
+		return nil, internalErrors.NewValidationError(&id, "ID is nil")
+	}
+
+	sqlSelect :=
+		"SELECT id, name, person_type, email, phone, notes, created_date, updated_date " +
+			"FROM person " +
+			"WHERE id = ?"
+
+	row := repository.database.QueryRow(sqlSelect, id)
+	result, err := repository.mapRow(row, "GetById", id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			slog.Info("person_repository.GetById: No result found for ID", "ID", id, "error", err.Error())
+			return nil, internalErrors.NewNotFoundError("ID: '" + id.String() + "'")
+		}
+		return nil, err
+	}
+
+	return result, err
+}
+
+// mapRow can return InternalServiceError
+func (repository *PersonRepository) mapRow(
+	scanner interface{ Scan(...interface{}) error },
+	methodName string,
+	ID *uuid.UUID) (*models.Person, error) {
+	var result models.Person
+	var createdDate, updatedDate sql.NullString
+
+	err := scanner.Scan(
+		&result.ID,
+		&result.Name,
+		&result.PersonType,
+		&result.Email,
+		&result.Phone,
+		&result.Notes,
+		&createdDate,
+		&updatedDate,
+	)
+
+	if err != nil {
+		if err.Error() == "constraint failed: UNIQUE constraint failed: person.id (1555)" {
+			var IDString string
+			if ID != nil {
+				IDString = ID.String()
+			} else {
+				IDString = "[not set]"
+			}
+			slog.Info(
+				"person_repository.createPerson: UNIQUE constraint failed",
+				"ID", IDString)
+			return nil, internalErrors.NewConflictError(
+				"ID already exists in database: '" + IDString + "'")
+		}
+		return nil, err
+	}
+
+	if createdDate.Valid {
+		timestamp, err := time.Parse(time.RFC3339, createdDate.String)
+		if err != nil {
+			slog.Error("person_repository."+methodName+": Error parsing createdDate",
+				"createdDate", createdDate,
+				"error", err.Error())
+			return nil, internalErrors.NewInternalServiceError("Error parsing createdDate: " + err.Error())
+		}
+		result.CreatedDate = timestamp
+	}
+
+	if updatedDate.Valid {
+		timestamp, err := time.Parse(time.RFC3339, updatedDate.String)
+		if err != nil {
+			slog.Error("person_repository."+methodName+": Error parsing updatedDate",
+				"updatedDate", updatedDate,
+				"error", err.Error())
+			return nil, internalErrors.NewInternalServiceError("Error parsing updatedDate: " + err.Error())
+		}
+		result.UpdatedDate = &timestamp
+	}
+
+	return &result, nil
+}

--- a/internal/repositories/person_repository_integration_test.go
+++ b/internal/repositories/person_repository_integration_test.go
@@ -1,0 +1,177 @@
+package repositories_test
+
+import (
+	"errors"
+	configPackage "jobsearchtracker/internal/config"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/repositories"
+	"jobsearchtracker/internal/testutil/dependencyinjection"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupPersonRepository(t *testing.T) *repositories.PersonRepository {
+	config := &configPackage.Config{
+		DatabaseMigrationsPath:               "../../migrations",
+		IsDatabaseMigrationsPathAbsolutePath: false,
+	}
+
+	container := dependencyinjection.SetupPersonRepositoryTestContainer(t, *config)
+
+	var personRepository *repositories.PersonRepository
+	err := container.Invoke(func(repository *repositories.PersonRepository) {
+		personRepository = repository
+	})
+	assert.NoError(t, err)
+
+	return personRepository
+}
+
+// -------- Create tests: --------
+
+func TestCreate_ShouldInsertPerson(t *testing.T) {
+	personRepository := setupPersonRepository(t)
+
+	id := uuid.New()
+	email := "some@email.tld"
+	phone := "123456"
+	notes := "Some Notes"
+	createdDate := time.Now().AddDate(0, 0, -2)
+	updatedDate := time.Now().AddDate(0, 0, -1)
+
+	person := models.CreatePerson{
+		ID:          &id,
+		Name:        "Person Name",
+		PersonType:  models.PersonTypeDeveloper,
+		Email:       &email,
+		Phone:       &phone,
+		Notes:       &notes,
+		CreatedDate: &createdDate,
+		UpdatedDate: &updatedDate,
+	}
+
+	insertedPerson, err := personRepository.Create(&person)
+	assert.NoError(t, err)
+	assert.NotNil(t, insertedPerson)
+
+	assert.Equal(t, *person.ID, insertedPerson.ID)
+	assert.Equal(t, person.Name, insertedPerson.Name)
+	assert.Equal(t, person.PersonType, insertedPerson.PersonType)
+	assert.Equal(t, person.Email, insertedPerson.Email)
+	assert.Equal(t, person.Phone, insertedPerson.Phone)
+	assert.Equal(t, person.Notes, insertedPerson.Notes)
+
+	personToInsertCreatedDate := person.CreatedDate.Format(time.RFC3339)
+	insertedPersonCreatedDate := insertedPerson.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, personToInsertCreatedDate, insertedPersonCreatedDate)
+
+	personToInsertUpdatedDate := person.UpdatedDate.Format(time.RFC3339)
+	insertedPersonUpdatedDate := insertedPerson.UpdatedDate.Format(time.RFC3339)
+	assert.Equal(t, personToInsertUpdatedDate, insertedPersonUpdatedDate)
+}
+
+func TestCreate_ShouldInsertPersonWithMinimumRequiredFields(t *testing.T) {
+	personRepository := setupPersonRepository(t)
+
+	person := models.CreatePerson{
+		Name:       "Abc Def",
+		PersonType: models.PersonTypeCEO,
+	}
+
+	createdDateApproximation := time.Now().Format(time.RFC3339)
+	insertedPerson, err := personRepository.Create(&person)
+	assert.NoError(t, err)
+	assert.NotNil(t, insertedPerson)
+
+	assert.NotNil(t, insertedPerson.ID)
+	assert.NotNil(t, insertedPerson.Name)
+	assert.NotNil(t, insertedPerson.PersonType)
+	assert.Nil(t, insertedPerson.Email)
+	assert.Nil(t, insertedPerson.Phone)
+	assert.Nil(t, insertedPerson.Notes)
+
+	insertedPersonCreatedDate := insertedPerson.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, createdDateApproximation, insertedPersonCreatedDate)
+
+	assert.Nil(t, insertedPerson.UpdatedDate)
+}
+
+func TestCreate_ShouldReturnConflictErrorOnDuplicatePersonId(t *testing.T) {
+	personRepository := setupPersonRepository(t)
+
+	id := uuid.New()
+
+	person1 := models.CreatePerson{
+		ID:         &id,
+		Name:       "Not Real",
+		PersonType: models.PersonTypeJobContact,
+	}
+	insertedPerson1, err := personRepository.Create(&person1)
+	assert.NoError(t, err)
+	assert.NotNil(t, insertedPerson1)
+	assert.NotNil(t, insertedPerson1.ID)
+
+	person2 := models.CreatePerson{
+		ID:         &id,
+		Name:       "Never Duplicated",
+		PersonType: models.PersonTypeJobAdvertiser,
+	}
+	insertedPerson2, err := personRepository.Create(&person2)
+	assert.Nil(t, insertedPerson2)
+	assert.Error(t, err)
+
+	var conflictError *internalErrors.ConflictError
+	assert.True(t, errors.As(err, &conflictError))
+	assert.Equal(t,
+		"conflict error on insert: ID already exists in database: '"+id.String()+"'",
+		err.Error())
+}
+
+// -------- GetById tests: --------
+
+func TestGetById_ShouldGetPerson(t *testing.T) {
+	personRepository := setupPersonRepository(t)
+
+	id := uuid.New()
+	personToInsert := models.CreatePerson{
+		ID:         &id,
+		Name:       "Joe Sparks",
+		PersonType: models.PersonTypeDeveloper,
+	}
+	insertedPerson, err := personRepository.Create(&personToInsert)
+	assert.NoError(t, err)
+	assert.NotNil(t, insertedPerson)
+
+	retrievedPerson, err := personRepository.GetById(&id)
+	assert.Nil(t, err)
+	assert.NotNil(t, retrievedPerson)
+
+	assert.Equal(t, id, retrievedPerson.ID)
+}
+
+func TestGetById_ShouldReturnValidationErrorIfPersonIDIsNil(t *testing.T) {
+	personRepository := setupPersonRepository(t)
+
+	person, err := personRepository.GetById(nil)
+	assert.Nil(t, person)
+	assert.NotNil(t, err)
+	assert.Equal(t, "validation error on field 'ID': ID is nil", err.Error())
+}
+
+func TestGetById_ShouldReturnNotFoundErrorIfPersonIDDoesNotExist(t *testing.T) {
+	personRepository := setupPersonRepository(t)
+
+	id := uuid.New()
+
+	person, err := personRepository.GetById(&id)
+	assert.Nil(t, person)
+	assert.NotNil(t, err)
+	assert.Equal(t,
+		"error: object not found: ID: '"+id.String()+"'",
+		err.Error(),
+		"Wrong error returned")
+}

--- a/internal/services/person_service.go
+++ b/internal/services/person_service.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/repositories"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type PersonService struct {
+	personRepository *repositories.PersonRepository
+}
+
+func NewPersonService(personRepository *repositories.PersonRepository) *PersonService {
+	return &PersonService{personRepository: personRepository}
+}
+
+// CreatePerson can return ConflictError, InternalServiceError, ValidationError
+func (personService *PersonService) CreatePerson(person *models.CreatePerson) (*models.Person, error) {
+	if person == nil {
+		slog.Error("person_service.CreatePerson: person is nil")
+		return nil, internalErrors.NewValidationError(nil, "CreatePerson is nil")
+	}
+
+	err := person.Validate()
+	if err != nil {
+		var personID string
+		if person.ID != nil {
+			personID = person.ID.String()
+		} else {
+			personID = "[not set]"
+		}
+		slog.Info("person_service.CreatePerson: Person to create is invalid. ", "ID", personID, "error", err)
+		return nil, err
+	}
+
+	if person.CreatedDate == nil {
+		createdDate := time.Now()
+		person.CreatedDate = &createdDate
+	} else if person.CreatedDate.IsZero() {
+		createdDate := time.Now()
+		person.CreatedDate = &createdDate
+		slog.Info(
+			"person_service.createPerson: person.CreatedDate is zero. Setting to '" + person.CreatedDate.String() + "'")
+	}
+
+	insertedPerson, err := personService.personRepository.Create(person)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("person_service.createPerson: Inserted person.", "person.ID", insertedPerson.ID)
+	return insertedPerson, nil
+}
+
+// GetPersonById can return ConflictError, InternalServiceError, NewValidationError
+func (personService *PersonService) GetPersonById(personId *uuid.UUID) (*models.Person, error) {
+	if personId == nil {
+		personIdString := "person ID"
+		err := internalErrors.NewValidationError(&personIdString, "personId is required")
+		slog.Info("personService.GetPersonById: Failed to get person", "error", err)
+		return nil, err
+	}
+
+	// can return InternalServiceError, NotFoundError, ValidationError
+	person, err := personService.personRepository.GetById(personId)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("PersonService.GetPersonById: Retrieved person.", "person.ID", person.ID.String())
+
+	return person, nil
+}

--- a/internal/services/person_service_integration_test.go
+++ b/internal/services/person_service_integration_test.go
@@ -1,0 +1,149 @@
+package services_test
+
+import (
+	"errors"
+	configPackage "jobsearchtracker/internal/config"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/services"
+	"jobsearchtracker/internal/testutil/dependencyinjection"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupPersonService(t *testing.T) *services.PersonService {
+	config := &configPackage.Config{
+		DatabaseMigrationsPath:               "../../migrations",
+		IsDatabaseMigrationsPathAbsolutePath: false,
+	}
+
+	container := dependencyinjection.SetupPersonServiceTestContainer(t, *config)
+
+	var personService *services.PersonService
+	err := container.Invoke(func(personSvc *services.PersonService) {
+		personService = personSvc
+	})
+	assert.NoError(t, err)
+
+	return personService
+}
+
+// -------- CreatePerson tests: --------
+
+func TestCreatePerson_ShouldWork(t *testing.T) {
+	personService := setupPersonService(t)
+
+	id := uuid.New()
+	name := "Dude Janesson"
+	email := "em@ai.l"
+	phone := "321"
+	Notes := "Text"
+	createdDate := time.Now().AddDate(1, 0, 0)
+	updatedDate := time.Now().AddDate(0, -2, 0)
+
+	personToInsert := models.CreatePerson{
+		ID:          &id,
+		Name:        name,
+		PersonType:  models.PersonTypeCEO,
+		Email:       &email,
+		Phone:       &phone,
+		Notes:       &Notes,
+		CreatedDate: &createdDate,
+		UpdatedDate: &updatedDate,
+	}
+
+	insertedPerson, err := personService.CreatePerson(&personToInsert)
+	assert.NoError(t, err)
+	assert.NotNil(t, insertedPerson)
+
+	assert.Equal(t, id, insertedPerson.ID)
+	assert.Equal(t, name, insertedPerson.Name)
+	assert.Equal(t, personToInsert.PersonType, insertedPerson.PersonType)
+	assert.Equal(t, &email, insertedPerson.Email)
+	assert.Equal(t, &phone, insertedPerson.Phone)
+
+	createdDateToInsert := createdDate.Format(time.RFC3339)
+	insertedCreatedDate := insertedPerson.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, createdDateToInsert, insertedCreatedDate)
+
+	updatedDateToInsert := updatedDate.Format(time.RFC3339)
+	insertedUpdatedDate := insertedPerson.UpdatedDate.Format(time.RFC3339)
+	assert.Equal(t, updatedDateToInsert, insertedUpdatedDate)
+}
+
+func TestCreatePerson_ShouldHandleEmptyFields(t *testing.T) {
+	personService := setupPersonService(t)
+
+	name := "Sven Joe"
+
+	personToInsert := models.CreatePerson{
+		Name:       name,
+		PersonType: models.PersonTypeCEO,
+	}
+
+	insertedDateApproximation := time.Now().Format(time.RFC3339)
+	insertedPerson, err := personService.CreatePerson(&personToInsert)
+	assert.NoError(t, err)
+	assert.NotNil(t, insertedPerson)
+
+	assert.NotNil(t, insertedPerson.ID)
+	assert.Equal(t, name, insertedPerson.Name)
+	assert.Equal(t, personToInsert.PersonType, insertedPerson.PersonType)
+	assert.Nil(t, insertedPerson.Email)
+	assert.Nil(t, insertedPerson.Phone)
+
+	insertedCreatedDate := insertedPerson.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, insertedDateApproximation, insertedCreatedDate)
+
+	assert.Nil(t, insertedPerson.UpdatedDate)
+}
+
+// -------- GetPersonById tests: --------
+
+func TestGetPersonById_ShouldWork(t *testing.T) {
+	personService := setupPersonService(t)
+
+	id := uuid.New()
+	name := "Some Name"
+	email := "an@email.address"
+	phone := "128932019"
+	Notes := "No notes here..."
+	createdDate := time.Now().AddDate(0, 2, 0)
+	updatedDate := time.Now().AddDate(0, -1, 0)
+
+	personToInsert := models.CreatePerson{
+		ID:          &id,
+		Name:        name,
+		PersonType:  models.PersonTypeOther,
+		Email:       &email,
+		Phone:       &phone,
+		Notes:       &Notes,
+		CreatedDate: &createdDate,
+		UpdatedDate: &updatedDate,
+	}
+
+	insertedPerson, err := personService.CreatePerson(&personToInsert)
+	assert.NoError(t, err)
+	assert.NotNil(t, insertedPerson)
+
+	retrievedPerson, err := personService.GetPersonById(&id)
+	assert.NoError(t, err)
+	assert.NotNil(t, retrievedPerson)
+
+}
+
+func TestGetPersonById_ShouldReturnNotFoundErrorForAnIdThatDoesNotExist(t *testing.T) {
+	personService := setupPersonService(t)
+
+	id := uuid.New()
+	nilPerson, err := personService.GetPersonById(&id)
+	assert.Nil(t, nilPerson)
+
+	assert.NotNil(t, err)
+	var notFoundError *internalErrors.NotFoundError
+	assert.True(t, errors.As(err, &notFoundError))
+	assert.Equal(t, "error: object not found: ID: '"+id.String()+"'", err.Error())
+}

--- a/internal/services/person_service_test.go
+++ b/internal/services/person_service_test.go
@@ -1,0 +1,89 @@
+package services
+
+import (
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- CreatePerson tests: --------
+
+func TestCreatePerson_ShouldReturnValidationErrorOnNilPerson(t *testing.T) {
+	personService := NewPersonService(nil)
+
+	nilPerson, err := personService.CreatePerson(nil)
+	assert.Nil(t, nilPerson)
+	assert.NotNil(t, err)
+
+	var validationError *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationError))
+	assert.Equal(t, "validation error: CreatePerson is nil", err.Error())
+}
+
+func TestCreatePerson_ShouldReturnValidationErrorOnEmptyName(t *testing.T) {
+	personService := NewPersonService(nil)
+
+	person := models.CreatePerson{
+		Name:       "",
+		PersonType: models.PersonTypeDeveloper,
+	}
+
+	nilPerson, err := personService.CreatePerson(&person)
+	assert.Nil(t, nilPerson)
+	assert.NotNil(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error on field 'Name': person name is empty", err.Error())
+}
+
+func TestCreatePerson_ShouldReturnValidationErrorOnInvalidPersonType(t *testing.T) {
+	personService := NewPersonService(nil)
+
+	person := models.CreatePerson{
+		Name: "Random",
+	}
+
+	nilPerson, err := personService.CreatePerson(&person)
+	assert.Nil(t, nilPerson)
+	assert.NotNil(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error on field 'PersonType': person type is invalid", err.Error())
+}
+
+func TestCreatePerson_ShouldReturnValidationErrorOnUnsetUpdatedDate(t *testing.T) {
+	personService := NewPersonService(nil)
+
+	person := models.CreatePerson{
+		Name:        "something here",
+		PersonType:  models.PersonTypeUnknown,
+		UpdatedDate: &time.Time{},
+	}
+
+	nilPerson, err := personService.CreatePerson(&person)
+	assert.Nil(t, nilPerson)
+	assert.NotNil(t, err)
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t,
+		"validation error on field 'UpdatedDate': updated date is zero. It should either be 'nil' or a recent date. Given that this is an insert, it is recommended to use nil",
+		err.Error())
+}
+
+// -------- GetPersonById tests: --------
+func TestGetPersonById_ShouldReturnValidationErrorIfPersonIdIsNil(t *testing.T) {
+	personService := NewPersonService(nil)
+
+	nilPerson, err := personService.GetPersonById(nil)
+	assert.Nil(t, nilPerson)
+	assert.NotNil(t, err)
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error on field 'person ID': personId is required", err.Error())
+}

--- a/internal/testutil/dependencyinjection/container.go
+++ b/internal/testutil/dependencyinjection/container.go
@@ -60,6 +60,8 @@ func SetupDatabaseTestContainer(t *testing.T, config configPackage.Config) *dig.
 	return container
 }
 
+// -------- Company containers: --------
+
 func SetupCompanyRepositoryTestContainer(t *testing.T, config configPackage.Config) *dig.Container {
 	container := SetupDatabaseTestContainer(t, config)
 
@@ -94,6 +96,48 @@ func SetupCompanyHandlerTestContainer(t *testing.T, config configPackage.Config)
 	})
 	if err != nil {
 		log.Fatal("Failed to provide companyHandler", err)
+	}
+
+	return container
+}
+
+// -------- Person containers: --------
+
+func SetupPersonRepositoryTestContainer(t *testing.T, config configPackage.Config) *dig.Container {
+	container := SetupDatabaseTestContainer(t, config)
+
+	err := container.Provide(func(db *sql.DB) *repositories.PersonRepository {
+		return repositories.NewPersonRepository(db)
+	})
+
+	if err != nil {
+		log.Fatal("Failed to provide personRepository", err)
+	}
+
+	return container
+}
+
+func SetupPersonServiceTestContainer(t *testing.T, config configPackage.Config) *dig.Container {
+	container := SetupPersonRepositoryTestContainer(t, config)
+
+	err := container.Provide(func(personRepository *repositories.PersonRepository) *services.PersonService {
+		return services.NewPersonService(personRepository)
+	})
+	if err != nil {
+		log.Fatal("Failed to provide personService", err)
+	}
+
+	return container
+}
+
+func SetupPersonHandlerTestContainer(t *testing.T, config configPackage.Config) *dig.Container {
+	container := SetupPersonServiceTestContainer(t, config)
+
+	err := container.Provide(func(personService *services.PersonService) *apiV1.PersonHandler {
+		return apiV1.NewPersonHandler(personService)
+	})
+	if err != nil {
+		log.Fatal("Failed to provide personHandler", err)
 	}
 
 	return container

--- a/migrations/0002_add_person.down.sql
+++ b/migrations/0002_add_person.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE person;

--- a/migrations/0002_add_person.up.sql
+++ b/migrations/0002_add_person.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS person
+(
+    id           UUID   PRIMARY KEY,
+    name         TEXT   NOT NULL,
+    person_type  TEXT CHECK (person_type IN ('CEO', 'CTO', 'developer', 'externalRecruiter', 'internalRecruiter', 'HR',
+                                             'jobAdvertiser', 'jobContact', 'other', 'unknown'))    NOT NULL,
+    email        TEXT   NULLABLE UNIQUE,
+    phone        TEXT   NULLABLE,
+    notes        TEXT   NULLABLE,
+    created_date DATETIME   NOT NULL    DEFAULT CURRENT_TIMESTAMP,
+    updated_date DATETIME NULLABLE
+);


### PR DESCRIPTION
- Added SQL migration to create `person` table.
- Added `Person` and `CreatePerson` structs and `PersonType` enum.
- Added `PersonRepository` along with `CreatePerson` and `GetByID`.
- Added `PersonService` along with `CreatePerson` and `GetByID`.
- Added `PersonHandler` along with `Create` and `GetPersonByID`.
- Added endpoints to `server.go`.