### PR TITLE
Add Application Create And GetById

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -27,6 +27,10 @@ func NewServer(database *sql.DB, logger *slog.Logger) *Server {
 	personService := services.NewPersonService(personRepository)
 	personHandler := apiV1.NewPersonHandler(personService)
 
+	applicationRepository := repositories.NewApplicationRepository(database)
+	applicationService := services.NewApplicationService(applicationRepository)
+	applicationHandler := apiV1.NewApplicationHandler(applicationService)
+
 	router := mux.NewRouter()
 
 	router.HandleFunc("/api/v1/company/new", companyHandler.CreateCompany).Methods(http.MethodPost)
@@ -42,6 +46,9 @@ func NewServer(database *sql.DB, logger *slog.Logger) *Server {
 	router.HandleFunc("/api/v1/person/get/all", personHandler.GetAllPersons).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/person/update", personHandler.UpdatePerson).Methods(http.MethodPost)
 	router.HandleFunc("/api/v1/person/delete/{id}", personHandler.DeletePerson).Methods(http.MethodDelete)
+
+	router.HandleFunc("/api/v1/application/new", applicationHandler.CreateApplication).Methods(http.MethodPost)
+	router.HandleFunc("/api/v1/application/get/id/{id}", applicationHandler.GetApplicationByID).Methods(http.MethodGet)
 
 	logger.Info("Server created. Returning Server.")
 	return &Server{router: router, logger: logger}

--- a/internal/api/v1/handlers/application_handlers.go
+++ b/internal/api/v1/handlers/application_handlers.go
@@ -1,0 +1,175 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"jobsearchtracker/internal/api/v1/requests"
+	"jobsearchtracker/internal/api/v1/responses"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/services"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+type ApplicationHandler struct {
+	applicationService *services.ApplicationService
+}
+
+func NewApplicationHandler(applicationService *services.ApplicationService) *ApplicationHandler {
+	return &ApplicationHandler{applicationService: applicationService}
+}
+
+func (applicationHandler *ApplicationHandler) CreateApplication(writer http.ResponseWriter, request *http.Request) {
+	var createApplicationRequest requests.CreateApplicationRequest
+	if err := json.NewDecoder(request.Body).Decode(&createApplicationRequest); err != nil {
+		slog.Info("v1.ApplicationHandler.CreateApplication: invalid request body", "error", err)
+		http.Error(writer, "invalid request body: Unable to parse JSON", http.StatusBadRequest)
+		return
+	}
+
+	// can return ValidationError
+	createApplicationModel, err := createApplicationRequest.ToModel()
+	if err != nil {
+		slog.Info(
+			"v1.ApplicationHandler.CreateApplication: Unable to convert CreateApplicationRequest to model", "error",
+			err)
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if createApplicationModel == nil {
+		slog.Info("v1.ApplicationHandler.CreateApplication: CreateApplicationModel is nil", "error", err)
+		http.Error(writer,
+			"Unable to convert request to internal model: Internal model is nil",
+			http.StatusInternalServerError)
+		return
+	}
+
+	// can return ConflictError, InternalServiceError, ValidationError
+	createdApplication, err := applicationHandler.applicationService.CreateApplication(createApplicationModel)
+	if err != nil {
+		var conflictErr *internalErrors.ConflictError
+		var internalServiceErr *internalErrors.InternalServiceError
+		var validationErr *internalErrors.ValidationError
+
+		var errorMessage string
+		var status int
+
+		if errors.As(err, &conflictErr) {
+			errorMessage = "Conflict error on insert: ID already exists"
+			status = http.StatusConflict
+			slog.Info("v1.ApplicationHandler.CreateApplication: ConflictError creating application", "error", err)
+		} else if errors.As(err, &internalServiceErr) {
+			errorMessage = "Internal service error while creating application"
+			status = http.StatusInternalServerError
+			slog.Error("v1.ApplicationHandler.CreateApplication: "+errorMessage, "error", err)
+		} else if errors.As(err, &validationErr) {
+			errorMessage = err.Error()
+			status = http.StatusBadRequest
+			slog.Info(
+				"v1.ApplicationHandler.CreateApplication: ValidationError while creating application", "error",
+				err)
+		} else {
+			errorMessage = "Unknown internal error while creating application"
+			status = http.StatusInternalServerError
+			slog.Error("v1.ApplicationHandler.CreateApplication: Error while creating application", "error", err)
+		}
+		http.Error(writer, errorMessage, status)
+
+		return
+	}
+
+	// can return InternalServiceError
+	applicationResponse, err := responses.NewApplicationResponse(createdApplication)
+	if err != nil {
+		slog.Error(
+			"v1.ApplicationHandler.CreateApplication: Unable to convert internal model to response", "error",
+			err)
+		http.Error(writer, "Error: Unable to convert internal model to response", http.StatusInternalServerError)
+	}
+
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(http.StatusCreated)
+	err = json.NewEncoder(writer).Encode(applicationResponse)
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		slog.Error("v1.ApplicationHandler.CreateApplication: Unable to write response", "error", err)
+		http.Error(writer, "Application created but unable to create response", http.StatusInternalServerError)
+
+		return
+	}
+}
+
+func (applicationHandler *ApplicationHandler) GetApplicationByID(writer http.ResponseWriter, request *http.Request) {
+	vars := mux.Vars(request)
+	applicationIDStr := vars["id"]
+
+	if applicationIDStr == "" {
+		slog.Info("v1.ApplicationHandler.GetApplicationById: application ID is empty")
+		http.Error(writer, "application ID is empty", http.StatusBadRequest)
+		return
+	}
+
+	applicationID, err := uuid.Parse(applicationIDStr)
+	if err != nil {
+		slog.Info("v1.ApplicationHandler.GetApplicationById: application ID is not a valid UUID")
+		http.Error(writer, "application ID is not a valid UUID", http.StatusBadRequest)
+		return
+	}
+
+	var internalServiceError *internalErrors.InternalServiceError
+	var notFoundError *internalErrors.NotFoundError
+	var validationErr *internalErrors.ValidationError
+
+	// can return InternalServiceError, NotFoundError, ValidationError
+	application, err := applicationHandler.applicationService.GetApplicationById(&applicationID)
+	if err != nil {
+		var errorMessage string
+		var status int
+
+		if errors.As(err, &internalServiceError) {
+			errorMessage = "Internal service error while retrieving application"
+			status = http.StatusInternalServerError
+			slog.Error("v1.ApplicationHandler.GetApplicationByID: "+errorMessage, "error", err)
+		} else if errors.As(err, &notFoundError) {
+			errorMessage = "application not found"
+			status = http.StatusNotFound
+			slog.Info("v1.ApplicationHandler.GetApplicationByID: "+errorMessage, "error", err)
+		} else if errors.As(err, &validationErr) {
+			errorMessage = err.Error()
+			status = http.StatusBadRequest
+			slog.Info("v1.ApplicationHandler.GetApplicationByID: Validation error", "error", err)
+		}
+		http.Error(writer, errorMessage, status)
+
+		return
+	}
+
+	// can return InternalServiceError
+	applicationResponse, err := responses.NewApplicationResponse(application)
+	if err != nil {
+		slog.Error(
+			"v1.ApplicationHandler.GetApplicationByID: Unable to convert internal model to response", "error",
+			err)
+		http.Error(writer, "Error: Unable to convert internal model to response", http.StatusInternalServerError)
+	}
+
+	writer.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(writer).Encode(applicationResponse)
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		slog.Error("v1.ApplicationHandler.GetApplicationByID: Unable to write response", "error", err)
+		http.Error(writer, "Application found but unable to build response", http.StatusInternalServerError)
+
+		return
+	}
+
+	slog.Info(
+		"v1.ApplicationHandler.GetApplicationByID: retrieved application successfully",
+		"application.ID", application.ID.String())
+
+	return
+}

--- a/internal/api/v1/handlers/application_handlers_integration_test.go
+++ b/internal/api/v1/handlers/application_handlers_integration_test.go
@@ -1,0 +1,381 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"jobsearchtracker/internal/api/v1/handlers"
+	"jobsearchtracker/internal/api/v1/requests"
+	"jobsearchtracker/internal/api/v1/responses"
+	configPackage "jobsearchtracker/internal/config"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/repositories"
+	"jobsearchtracker/internal/testutil/dependencyinjection"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupApplicationHandler(t *testing.T) (*handlers.ApplicationHandler, *repositories.CompanyRepository) {
+	config := configPackage.Config{
+		DatabaseMigrationsPath:               "../../../../migrations",
+		IsDatabaseMigrationsPathAbsolutePath: false,
+	}
+
+	container := dependencyinjection.SetupApplicationHandlerTestContainer(t, config)
+
+	var applicationHandler *handlers.ApplicationHandler
+	err := container.Invoke(func(applicationHand *handlers.ApplicationHandler) {
+		applicationHandler = applicationHand
+	})
+	assert.NoError(t, err)
+
+	var companyRepository *repositories.CompanyRepository
+	err = container.Invoke(func(repository *repositories.CompanyRepository) {
+		companyRepository = repository
+	})
+	assert.NoError(t, err)
+
+	return applicationHandler, companyRepository
+}
+
+// -------- CreateApplication tests: --------
+
+func TestCreateApplication_ShouldInsertAndReturnApplication(t *testing.T) {
+	applicationHandler, companyRepository := setupApplicationHandler(t)
+
+	companyID := createCompany(t, companyRepository)
+	recruiterID := createCompany(t, companyRepository)
+
+	id := uuid.New()
+	jobTitle := "Job Title"
+	jobAdURL := "Job Ad URL"
+	country := "Some Country"
+	area := "Some Area"
+	weekdaysInOffice := 9
+	estimatedCycleTime := 8
+	estimatedCommuteTime := 7
+	applicationDate := time.Now().AddDate(0, 0, -9)
+
+	requestBody := requests.CreateApplicationRequest{
+		ID:                   &id,
+		CompanyID:            companyID,
+		RecruiterID:          recruiterID,
+		JobTitle:             &jobTitle,
+		JobAdURL:             &jobAdURL,
+		Country:              &country,
+		Area:                 &area,
+		RemoteStatusType:     requests.RemoteStatusTypeHybrid,
+		WeekdaysInOffice:     &weekdaysInOffice,
+		EstimatedCycleTime:   &estimatedCycleTime,
+		EstimatedCommuteTime: &estimatedCommuteTime,
+		ApplicationDate:      &applicationDate,
+	}
+
+	requestBytes, err := json.Marshal(requestBody)
+	assert.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodPost, "/api/v1/application/new", bytes.NewBuffer(requestBytes))
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	createdDateApproximation := time.Now().Format(time.RFC3339)
+	applicationHandler.CreateApplication(responseRecorder, request)
+	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString)
+
+	var applicationResponse responses.ApplicationResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&applicationResponse)
+	assert.NoError(t, err)
+
+	assert.Equal(t, *requestBody.ID, applicationResponse.ID)
+	assert.Equal(t, *requestBody.CompanyID, *applicationResponse.CompanyID)
+	assert.Equal(t, *requestBody.RecruiterID, *applicationResponse.RecruiterID)
+	assert.Equal(t, *requestBody.JobTitle, *applicationResponse.JobTitle)
+	assert.Equal(t, *requestBody.JobAdURL, *applicationResponse.JobAdURL)
+	assert.Equal(t, *requestBody.Country, *applicationResponse.Country)
+	assert.Equal(t, *requestBody.Area, *applicationResponse.Area)
+	assert.Equal(t, requests.RemoteStatusTypeHybrid, applicationResponse.RemoteStatusType.String())
+	assert.Equal(t, *requestBody.WeekdaysInOffice, *applicationResponse.WeekdaysInOffice)
+	assert.Equal(t, *requestBody.EstimatedCycleTime, *applicationResponse.EstimatedCycleTime)
+	assert.Equal(t, *requestBody.EstimatedCommuteTime, *applicationResponse.EstimatedCommuteTime)
+
+	applicationToInsertApplicationDate := applicationDate.Format(time.RFC3339)
+	applicationResponseApplicationDate := applicationResponse.ApplicationDate.Format(time.RFC3339)
+	assert.Equal(t, applicationToInsertApplicationDate, applicationResponseApplicationDate)
+
+	applicationResponseCreatedDate := applicationResponse.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, createdDateApproximation, applicationResponseCreatedDate)
+
+	assert.Nil(t, applicationResponse.UpdatedDate)
+}
+
+func TestCreateApplication_ShouldReturnStatusConflictIfApplicationIDIsDuplicate(t *testing.T) {
+	applicationHandler, companyRepository := setupApplicationHandler(t)
+
+	applicationID := uuid.New()
+	recruiterID := createCompany(t, companyRepository)
+	firstJobTitle := "First Job Title"
+
+	firstRequestBody := requests.CreateApplicationRequest{
+		ID:               &applicationID,
+		RecruiterID:      recruiterID,
+		JobTitle:         &firstJobTitle,
+		RemoteStatusType: requests.RemoteStatusTypeHybrid,
+	}
+
+	firstRequestBytes, err := json.Marshal(firstRequestBody)
+	assert.NoError(t, err)
+
+	firstRequest, err :=
+		http.NewRequest(http.MethodPost, "/api/v1/application/new", bytes.NewBuffer(firstRequestBytes))
+	assert.NoError(t, err)
+
+	firstResponseRecorder := httptest.NewRecorder()
+
+	applicationHandler.CreateApplication(firstResponseRecorder, firstRequest)
+	assert.Equal(t, http.StatusCreated, firstResponseRecorder.Code)
+
+	var firstApplicationResponse responses.ApplicationResponse
+	err = json.NewDecoder(firstResponseRecorder.Body).Decode(&firstApplicationResponse)
+	assert.NoError(t, err)
+
+	assert.Equal(t, applicationID, firstApplicationResponse.ID)
+
+	secondJobTitle := "Second Job Title"
+	secondRequestBody := requests.CreateApplicationRequest{
+		ID:               &applicationID,
+		RecruiterID:      recruiterID,
+		JobTitle:         &secondJobTitle,
+		RemoteStatusType: models.RemoteStatusTypeRemote,
+	}
+
+	secondRequestBytes, err := json.Marshal(secondRequestBody)
+	assert.NoError(t, err)
+
+	secondRequest, err :=
+		http.NewRequest(http.MethodPost, "/api/v1/application/new", bytes.NewBuffer(secondRequestBytes))
+	assert.NoError(t, err)
+
+	secondResponseRecorder := httptest.NewRecorder()
+
+	applicationHandler.CreateApplication(secondResponseRecorder, secondRequest)
+	assert.Equal(t, http.StatusConflict, secondResponseRecorder.Code)
+
+	expectedError := "Conflict error on insert: ID already exists\n"
+	assert.Equal(t, expectedError, secondResponseRecorder.Body.String())
+}
+
+func TestCreateApplication_ShouldReturnErrorIfCompanyIDDoesNotExistInCompany(t *testing.T) {
+	applicationHandler, companyRepository := setupApplicationHandler(t)
+
+	applicationID := uuid.New()
+	companyID := uuid.New()
+	recruiterID := createCompany(t, companyRepository)
+	jobTitle := "Job Title"
+
+	requestBody := requests.CreateApplicationRequest{
+		ID:          &applicationID,
+		CompanyID:   &companyID,
+		RecruiterID: recruiterID,
+		JobTitle:    &jobTitle,
+	}
+
+	requestBytes, err := json.Marshal(requestBody)
+	assert.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodPost, "/api/v1/application/new", bytes.NewBuffer(requestBytes))
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	applicationHandler.CreateApplication(responseRecorder, request)
+	assert.Equal(t, http.StatusBadRequest, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.Equal(
+		t,
+		"validation error on field 'RemoteStatusType': RemoteStatusType is invalid\n",
+		responseBodyString)
+}
+
+func TestCreateApplication_ShouldReturnErrorIfRecruiterIDDoesNotExistInCompany(t *testing.T) {
+	applicationHandler, companyRepository := setupApplicationHandler(t)
+
+	applicationID := uuid.New()
+	companyID := createCompany(t, companyRepository)
+	recruiterID := uuid.New()
+	jobTitle := "Job Title"
+
+	requestBody := requests.CreateApplicationRequest{
+		ID:          &applicationID,
+		CompanyID:   companyID,
+		RecruiterID: &recruiterID,
+		JobTitle:    &jobTitle,
+	}
+
+	requestBytes, err := json.Marshal(requestBody)
+	assert.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodPost, "/api/v1/application/new", bytes.NewBuffer(requestBytes))
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	applicationHandler.CreateApplication(responseRecorder, request)
+	assert.Equal(t, http.StatusBadRequest, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.Equal(
+		t,
+		"validation error on field 'RemoteStatusType': RemoteStatusType is invalid\n",
+		responseBodyString)
+}
+
+// -------- GetApplicationById tests: --------
+
+func TestGetApplicationById_ShouldReturnApplication(t *testing.T) {
+	applicationHandler, companyRepository := setupApplicationHandler(t)
+
+	// Insert an application:
+
+	id := uuid.New()
+	companyID := createCompany(t, companyRepository)
+	recruiterID := createCompany(t, companyRepository)
+	jobTitle := "Job Title"
+	jobAdURL := "job Ad URL"
+	country := "country"
+	area := "area"
+	weekdaysInOffice := 6
+	estimatedCycleTime := 7
+	estimatedCommuteTime := 8
+	applicationDate := time.Now().AddDate(0, 0, -20)
+	requestBody := requests.CreateApplicationRequest{
+		ID:                   &id,
+		CompanyID:            companyID,
+		RecruiterID:          recruiterID,
+		JobTitle:             &jobTitle,
+		JobAdURL:             &jobAdURL,
+		Country:              &country,
+		Area:                 &area,
+		RemoteStatusType:     requests.RemoteStatusTypeOffice,
+		WeekdaysInOffice:     &weekdaysInOffice,
+		EstimatedCycleTime:   &estimatedCycleTime,
+		EstimatedCommuteTime: &estimatedCommuteTime,
+		ApplicationDate:      &applicationDate,
+	}
+	_, createdDateApproximation := insertApplication(t, applicationHandler, requestBody)
+
+	// Get the application:
+
+	getRequest, err := http.NewRequest(http.MethodGet, "/api/v1/application/get/id", nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	vars := map[string]string{
+		"id": id.String(),
+	}
+	getRequest = mux.SetURLVars(getRequest, vars)
+
+	applicationHandler.GetApplicationByID(responseRecorder, getRequest)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString)
+
+	var response responses.ApplicationResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&response)
+	assert.NoError(t, err)
+
+	assert.Equal(t, *requestBody.ID, response.ID)
+	assert.Equal(t, *requestBody.CompanyID, *response.CompanyID)
+	assert.Equal(t, *requestBody.RecruiterID, *response.RecruiterID)
+	assert.Equal(t, *requestBody.JobTitle, *response.JobTitle)
+	assert.Equal(t, *requestBody.JobAdURL, *response.JobAdURL)
+	assert.Equal(t, *requestBody.Country, *response.Country)
+	assert.Equal(t, *requestBody.Area, *response.Area)
+	assert.Equal(t, requests.RemoteStatusTypeOffice, response.RemoteStatusType.String())
+	assert.Equal(t, *requestBody.WeekdaysInOffice, *response.WeekdaysInOffice)
+	assert.Equal(t, *requestBody.EstimatedCycleTime, *response.EstimatedCycleTime)
+	assert.Equal(t, *requestBody.EstimatedCommuteTime, *response.EstimatedCommuteTime)
+
+	applicationToInsertApplicationDate := applicationDate.Format(time.RFC3339)
+	responseApplicationDate := response.ApplicationDate.Format(time.RFC3339)
+	assert.Equal(t, applicationToInsertApplicationDate, responseApplicationDate)
+
+	responseCreatedDate := response.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, *createdDateApproximation, responseCreatedDate)
+
+	assert.Nil(t, response.UpdatedDate)
+}
+
+func TestGetApplicationById_ShouldReturnNotFoundIfApplicationDoesNotExist(t *testing.T) {
+	applicationHandler, _ := setupApplicationHandler(t)
+
+	request, err := http.NewRequest(http.MethodGet, "/api/v1/application/get/id", nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	vars := map[string]string{
+		"id": uuid.New().String(),
+	}
+	request = mux.SetURLVars(request, vars)
+
+	applicationHandler.GetApplicationByID(responseRecorder, request)
+	assert.Equal(t, http.StatusNotFound, responseRecorder.Code)
+
+	firstResponseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, firstResponseBodyString, "Application not found\n")
+}
+
+// -------- Test helpers: --------
+
+func createCompany(t *testing.T, companyRepository *repositories.CompanyRepository) *uuid.UUID {
+
+	id := uuid.New()
+	company := models.CreateCompany{
+		ID:          &id,
+		Name:        "Example Company Name",
+		CompanyType: models.CompanyTypeEmployer,
+	}
+
+	insertedCompany, err := companyRepository.Create(&company)
+	assert.NoError(t, err)
+
+	return &insertedCompany.ID
+}
+
+func insertApplication(
+	t *testing.T, applicationHandler *handlers.ApplicationHandler, requestBody requests.CreateApplicationRequest) (
+	*responses.ApplicationResponse, *string) {
+
+	requestBytes, err := json.Marshal(requestBody)
+	assert.NoError(t, err)
+
+	createRequest, err := http.NewRequest(http.MethodPost, "/api/v1/application/new", bytes.NewBuffer(requestBytes))
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	createdDateApproximation := time.Now().Format(time.RFC3339)
+	applicationHandler.CreateApplication(responseRecorder, createRequest)
+	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString)
+
+	var createApplicationResponse responses.ApplicationResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&createApplicationResponse)
+	assert.NoError(t, err)
+
+	return &createApplicationResponse, &createdDateApproximation
+}

--- a/internal/api/v1/handlers/application_handlers_test.go
+++ b/internal/api/v1/handlers/application_handlers_test.go
@@ -1,0 +1,138 @@
+package handlers_test
+
+import (
+	"bytes"
+	v1 "jobsearchtracker/internal/api/v1/handlers"
+	"jobsearchtracker/internal/testutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- CreateApplication tests: --------
+
+func TestCreateApplication_ShouldRespondWithBadRequestStatus(t *testing.T) {
+	tests := []struct {
+		testName             string
+		inputRequest         *string
+		expectedResponseCode int
+		expectedErrorMessage string
+	}{
+		{
+			testName:             "body is nil",
+			inputRequest:         nil,
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n",
+		},
+		{
+			testName:             "body is empty",
+			inputRequest:         testutil.StringPtr(""),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n",
+		},
+		{
+			testName:             "body does not match CreateApplicationRequest",
+			inputRequest:         testutil.StringPtr(`{"application_job_title":"test"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error: CompanyID and RecruiterID cannot both be empty\n",
+		},
+		{
+			testName:             "body CompanyID and RecruiterID is missing",
+			inputRequest:         testutil.StringPtr(`{"job_title":"Random job title", "remote_status_type": "hybrid"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error: CompanyID and RecruiterID cannot both be empty\n",
+		},
+		{
+			testName:             "body JobTitle and JobAdURL is missing",
+			inputRequest:         testutil.StringPtr(`{"company_id": "8abb5944-761b-447c-8a77-11ba1108ff68", "remote_status_type": "hybrid"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error: JobTitle and JobAdURL cannot be both be empty\n",
+		},
+		{
+			testName:             "body RemoteStatusType is missing",
+			inputRequest:         testutil.StringPtr(`{"company_id": "8abb5944-761b-447c-8a77-11ba1108ff68", "job_title":"Random job title"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error on field 'RemoteStatusType': RemoteStatusType is invalid\n",
+		},
+		{
+			testName:             "body RemoteStatusType is invalid",
+			inputRequest:         testutil.StringPtr(`{"company_id": "8abb5944-761b-447c-8a77-11ba1108ff68", "job_title":"Random job title", "remote_status_type":"Blah"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error on field 'RemoteStatusType': RemoteStatusType is invalid\n",
+		},
+		{
+			testName:             "malformed json",
+			inputRequest:         testutil.StringPtr(`"JobTitle":"random title","remote_status_type":"hybrid"`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n"},
+	}
+
+	for _, test := range tests {
+		applicationHandler := v1.NewApplicationHandler(nil)
+		t.Run(test.testName, func(t *testing.T) {
+			var requestBody []byte
+			if test.inputRequest != nil {
+				requestBody = []byte(*test.inputRequest)
+			} else {
+				requestBody = nil
+			}
+
+			request, err := http.NewRequest(http.MethodPost, "/api/v1/application/new", bytes.NewBuffer(requestBody))
+			assert.NoError(t, err)
+
+			responseRecorder := httptest.NewRecorder()
+
+			applicationHandler.CreateApplication(responseRecorder, request)
+			assert.Equal(t, test.expectedResponseCode, responseRecorder.Code)
+
+			responseBodyString := responseRecorder.Body.String()
+			assert.Contains(t, responseBodyString, test.expectedErrorMessage)
+		})
+
+	}
+}
+
+// -------- GetApplicationById tests: --------
+
+func TestGetApplicationById_ShouldReturnErrorIfIdIsEmpty(t *testing.T) {
+	applicationHandler := v1.NewApplicationHandler(nil)
+
+	request, err := http.NewRequest(http.MethodPost, "/api/v1/application/get/id", nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	vars := map[string]string{
+		"id": "",
+	}
+	request = mux.SetURLVars(request, vars)
+
+	applicationHandler.GetApplicationByID(responseRecorder, request)
+	assert.Equal(t, http.StatusBadRequest, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.Equal(t, "application ID is empty\n", responseBodyString)
+}
+
+func TestGetApplicationById_ShouldReturnErrorIfIdIsNotUUID(t *testing.T) {
+	applicationHandler := v1.NewApplicationHandler(nil)
+
+	request, err := http.NewRequest(http.MethodPost, "/api/v1/application/get/id", nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	vars := map[string]string{
+		"id": "ID GOES HERE",
+	}
+	request = mux.SetURLVars(request, vars)
+
+	applicationHandler.GetApplicationByID(responseRecorder, request)
+	assert.Equal(t, http.StatusBadRequest, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.Equal(t, "application ID is not a valid UUID\n", responseBodyString)
+}

--- a/internal/api/v1/requests/application_requests.go
+++ b/internal/api/v1/requests/application_requests.go
@@ -1,0 +1,180 @@
+package requests
+
+import (
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CreateApplicationRequest struct {
+	ID                   *uuid.UUID       `json:"id,omitempty"`
+	CompanyID            *uuid.UUID       `json:"company_id,omitempty"`
+	RecruiterID          *uuid.UUID       `json:"recruiter_id,omitempty"`
+	JobTitle             *string          `json:"job_title,omitempty"`
+	JobAdURL             *string          `json:"job_ad_url,omitempty"`
+	Country              *string          `json:"country,omitempty"`
+	Area                 *string          `json:"area,omitempty"`
+	RemoteStatusType     RemoteStatusType `json:"remote_status_type"`
+	WeekdaysInOffice     *int             `json:"weekdays_in_office,omitempty"`
+	EstimatedCycleTime   *int             `json:"estimated_cycle_time,omitempty"`
+	EstimatedCommuteTime *int             `json:"estimated_commute_time,omitempty"`
+	ApplicationDate      *time.Time       `json:"application_date,omitempty"`
+}
+
+func (request *CreateApplicationRequest) validate() error {
+	if request.ID != nil {
+		err := uuid.Validate(request.ID.String())
+		if err != nil {
+			message := "ID is invalid"
+			slog.Info("CreateApplicationRequest.validate failed: " + message)
+			return internalErrors.NewValidationError(nil, message)
+		} else if *request.ID == uuid.Nil {
+			message := "ID is empty"
+			slog.Info("CreateApplicationRequest.Validate: "+message, "ID", request.ID)
+			return internalErrors.NewValidationError(nil, message)
+		}
+	}
+
+	if request.CompanyID != nil {
+		err := uuid.Validate(request.CompanyID.String())
+		if err != nil {
+			return internalErrors.NewValidationError(nil, "CompanyID is invalid")
+		}
+	}
+
+	if request.RecruiterID != nil {
+		err := uuid.Validate(request.RecruiterID.String())
+		if err != nil {
+			return internalErrors.NewValidationError(nil, "RecruiterID is invalid")
+		}
+	}
+
+	if (request.CompanyID == nil || *request.CompanyID == uuid.Nil) &&
+		(request.RecruiterID == nil || *request.RecruiterID == uuid.Nil) {
+		return internalErrors.NewValidationError(nil, "CompanyID and RecruiterID cannot both be empty")
+	}
+
+	if request.JobTitle != nil && *request.JobTitle == "" {
+		return internalErrors.NewValidationError(nil, "JobTitle is empty")
+	}
+
+	if request.JobAdURL != nil && *request.JobAdURL == "" {
+		return internalErrors.NewValidationError(nil, "JobAdURL is empty")
+	}
+
+	if request.JobTitle == nil && request.JobAdURL == nil {
+		return internalErrors.NewValidationError(nil, "JobTitle and JobAdURL cannot be both be empty")
+	}
+
+	if !request.RemoteStatusType.IsValid() {
+		message := "RemoteStatusType is invalid"
+		slog.Info("CreateApplicationRequest.validate failed: " + message)
+		companyType := "RemoteStatusType"
+		return internalErrors.NewValidationError(&companyType, message)
+	}
+
+	if request.ApplicationDate != nil && request.ApplicationDate.IsZero() {
+		updatedDate := "ApplicationDate"
+		return internalErrors.NewValidationError(
+			&updatedDate,
+			"ApplicationDate is zero. It should either be 'nil' or a recent date. Given that this is an insert, it is recommended to use nil")
+	}
+
+	return nil
+}
+
+func (request *CreateApplicationRequest) ToModel() (*models.CreateApplication, error) {
+	err := request.validate()
+	if err != nil {
+		return nil, err
+	}
+
+	remoteStatusType, _ := request.RemoteStatusType.ToModel()
+
+	applicationModel := models.CreateApplication{
+		ID:                   request.ID,
+		CompanyID:            request.CompanyID,
+		RecruiterID:          request.RecruiterID,
+		JobTitle:             request.JobTitle,
+		JobAdURL:             request.JobAdURL,
+		Country:              request.Country,
+		Area:                 request.Area,
+		RemoteStatusType:     remoteStatusType,
+		WeekdaysInOffice:     request.WeekdaysInOffice,
+		EstimatedCycleTime:   request.EstimatedCycleTime,
+		EstimatedCommuteTime: request.EstimatedCommuteTime,
+		ApplicationDate:      request.ApplicationDate,
+	}
+
+	return &applicationModel, nil
+}
+
+type RemoteStatusType string
+
+const (
+	RemoteStatusTypeHybrid  = "hybrid"
+	RemoteStatusTypeOffice  = "office"
+	RemoteStatusTypeRemote  = "remote"
+	RemoteStatusTypeUnknown = "unknown"
+)
+
+func (remoteStatusType RemoteStatusType) IsValid() bool {
+	switch remoteStatusType {
+	case RemoteStatusTypeHybrid, RemoteStatusTypeOffice, RemoteStatusTypeRemote, RemoteStatusTypeUnknown:
+		return true
+	}
+	return false
+}
+
+func (remoteStatusType RemoteStatusType) String() string { return string(remoteStatusType) }
+
+// ToModel can return ValidationError
+func (remoteStatusType RemoteStatusType) ToModel() (models.RemoteStatusType, error) {
+	switch remoteStatusType {
+	case RemoteStatusTypeHybrid:
+		return models.RemoteStatusTypeHybrid, nil
+	case RemoteStatusTypeOffice:
+		return models.RemoteStatusTypeOffice, nil
+	case RemoteStatusTypeRemote:
+		return models.RemoteStatusTypeRemote, nil
+	case RemoteStatusTypeUnknown:
+		return models.RemoteStatusTypeUnknown, nil
+	default:
+		slog.Info("v1.types.toModel: Invalid RemoteStatusType: '" + remoteStatusType.String() + "'")
+		remoteStatusTypeString := "RemoteStatusType"
+		return "", internalErrors.NewValidationError(
+			&remoteStatusTypeString,
+			"invalid RemoteStatusType: '"+remoteStatusType.String()+"'")
+	}
+}
+
+func NewRemoteStatusType(modelRemoteStatusType *models.RemoteStatusType) (RemoteStatusType, error) {
+	if modelRemoteStatusType == nil {
+		slog.Info("v1.types.NewRemoteStatusType: modelRemoteStatusType is nil")
+		return "", internalErrors.NewInternalServiceError(
+			"Error trying to convert internal RemoteStatusType to external RemoteStatusType.")
+	}
+
+	switch *modelRemoteStatusType {
+	case models.RemoteStatusTypeHybrid:
+		return RemoteStatusTypeHybrid, nil
+	case models.RemoteStatusTypeOffice:
+		return RemoteStatusTypeOffice, nil
+	case models.RemoteStatusTypeRemote:
+		return RemoteStatusTypeRemote, nil
+	case models.RemoteStatusTypeUnknown:
+		return RemoteStatusTypeUnknown, nil
+
+	default:
+		slog.Info("v1.types.NewRemoteStatusType: Invalid modelRemoteStatusType: '" + modelRemoteStatusType.String() + "'")
+		return "", internalErrors.NewInternalServiceError(
+			"Error converting internal RemoteStatusType to external RemoteStatusType: '" + modelRemoteStatusType.String() + "'")
+	}
+}
+
+func (remoteStatusType RemoteStatusType) ToPointer() *RemoteStatusType {
+	return &remoteStatusType
+}

--- a/internal/api/v1/requests/application_requests_test.go
+++ b/internal/api/v1/requests/application_requests_test.go
@@ -1,0 +1,370 @@
+package requests
+
+import (
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/testutil"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- CreateApplicationRequest tests: --------
+
+func TestCreateApplicationRequestValidate_ShouldValidateRequest(t *testing.T) {
+	id := uuid.New()
+	companyID := uuid.New()
+	recruiterID := uuid.New()
+	jobTitle := "Job Title"
+	jobAdURL := "Job Ad URL"
+	country := "Some Country"
+	area := "Some Area"
+	weekdaysInOffice := 1
+	estimatedCycleTime := 2
+	estimatedCommuteTime := 3
+	applicationDate := time.Now().AddDate(0, 0, -1)
+
+	request := models.CreateApplication{
+		ID:                   &id,
+		CompanyID:            &companyID,
+		RecruiterID:          &recruiterID,
+		JobTitle:             &jobTitle,
+		JobAdURL:             &jobAdURL,
+		Country:              &country,
+		Area:                 &area,
+		RemoteStatusType:     models.RemoteStatusTypeHybrid,
+		WeekdaysInOffice:     &weekdaysInOffice,
+		EstimatedCycleTime:   &estimatedCycleTime,
+		EstimatedCommuteTime: &estimatedCommuteTime,
+		ApplicationDate:      &applicationDate,
+	}
+
+	err := request.Validate()
+	assert.NoError(t, err)
+}
+
+func TestCreateApplicationRequestValidate_ShouldReturnValidationErrors(t *testing.T) {
+	tests := []struct {
+		testName             string
+		CompanyID            *uuid.UUID
+		RecruiterID          *uuid.UUID
+		JobTitle             *string
+		JobAdURL             *string
+		remoteStatusType     RemoteStatusType
+		expectedErrorMessage string
+	}{
+		{
+			testName:             "nil CompanyID and nil RecruiterID",
+			CompanyID:            nil,
+			RecruiterID:          nil,
+			JobTitle:             testutil.StringPtr("Job Title"),
+			JobAdURL:             testutil.StringPtr("Job Ad URL"),
+			remoteStatusType:     RemoteStatusTypeOffice,
+			expectedErrorMessage: "validation error: CompanyID and RecruiterID cannot both be empty"},
+		{
+			testName:             "uuid.Nil CompanyID and nil RecruiterID",
+			CompanyID:            &uuid.Nil,
+			RecruiterID:          nil,
+			JobTitle:             testutil.StringPtr("Job Title"),
+			JobAdURL:             testutil.StringPtr("Job Ad URL"),
+			remoteStatusType:     RemoteStatusTypeOffice,
+			expectedErrorMessage: "validation error: CompanyID and RecruiterID cannot both be empty"},
+		{
+			testName:             "nil CompanyID and uuid.Nil RecruiterID",
+			CompanyID:            nil,
+			RecruiterID:          &uuid.Nil,
+			JobTitle:             testutil.StringPtr("Job Title"),
+			JobAdURL:             testutil.StringPtr("Job Ad URL"),
+			remoteStatusType:     RemoteStatusTypeOffice,
+			expectedErrorMessage: "validation error: CompanyID and RecruiterID cannot both be empty"},
+		{
+			testName:             "uuid.Nil CompanyID and uuid.Nil RecruiterID",
+			CompanyID:            &uuid.Nil,
+			RecruiterID:          &uuid.Nil,
+			JobTitle:             testutil.StringPtr("Job Title"),
+			JobAdURL:             testutil.StringPtr("Job Ad URL"),
+			remoteStatusType:     RemoteStatusTypeOffice,
+			expectedErrorMessage: "validation error: CompanyID and RecruiterID cannot both be empty"},
+		{
+			testName:             "nil JobTitle and nil JobAdURL",
+			CompanyID:            testutil.UUIDPtr(uuid.New()),
+			RecruiterID:          testutil.UUIDPtr(uuid.New()),
+			JobTitle:             nil,
+			JobAdURL:             nil,
+			remoteStatusType:     RemoteStatusTypeOffice,
+			expectedErrorMessage: "validation error: JobTitle and JobAdURL cannot be both be empty"},
+		{
+			testName:             "empty JobTitle and nil JobAdURL",
+			CompanyID:            testutil.UUIDPtr(uuid.New()),
+			RecruiterID:          testutil.UUIDPtr(uuid.New()),
+			JobTitle:             testutil.StringPtr(""),
+			JobAdURL:             nil,
+			remoteStatusType:     RemoteStatusTypeOffice,
+			expectedErrorMessage: "validation error: JobTitle is empty"},
+		{
+			testName:             "nil JobTitle and empty JobAdURL",
+			CompanyID:            testutil.UUIDPtr(uuid.New()),
+			RecruiterID:          testutil.UUIDPtr(uuid.New()),
+			JobTitle:             nil,
+			JobAdURL:             testutil.StringPtr(""),
+			remoteStatusType:     RemoteStatusTypeOffice,
+			expectedErrorMessage: "validation error: JobAdURL is empty"},
+		{
+			testName:             "empty JobTitle and empty JobAdURL",
+			CompanyID:            testutil.UUIDPtr(uuid.New()),
+			RecruiterID:          testutil.UUIDPtr(uuid.New()),
+			JobTitle:             testutil.StringPtr(""),
+			JobAdURL:             testutil.StringPtr(""),
+			remoteStatusType:     RemoteStatusTypeOffice,
+			expectedErrorMessage: "validation error: JobTitle is empty"},
+		{
+			testName:             "empty RemoteStatusType",
+			CompanyID:            testutil.UUIDPtr(uuid.New()),
+			RecruiterID:          testutil.UUIDPtr(uuid.New()),
+			JobTitle:             testutil.StringPtr("Job Title"),
+			JobAdURL:             testutil.StringPtr("Job Ad URL"),
+			remoteStatusType:     "",
+			expectedErrorMessage: "validation error on field 'RemoteStatusType': RemoteStatusType is invalid"},
+		{
+			testName:             "invalid RemoteStatusType",
+			CompanyID:            testutil.UUIDPtr(uuid.New()),
+			RecruiterID:          testutil.UUIDPtr(uuid.New()),
+			JobTitle:             testutil.StringPtr("Job Title"),
+			JobAdURL:             testutil.StringPtr("Job Ad URL"),
+			remoteStatusType:     "invalid RemoteStatusType",
+			expectedErrorMessage: "validation error on field 'RemoteStatusType': RemoteStatusType is invalid"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+
+			request := CreateApplicationRequest{
+				CompanyID:        test.CompanyID,
+				RecruiterID:      test.RecruiterID,
+				JobTitle:         test.JobTitle,
+				JobAdURL:         test.JobAdURL,
+				RemoteStatusType: test.remoteStatusType,
+			}
+
+			err := request.validate()
+			assert.NotNil(t, err)
+
+			var validationErr *internalErrors.ValidationError
+			assert.True(t, errors.As(err, &validationErr))
+
+			assert.Equal(t, test.expectedErrorMessage, err.Error())
+		})
+	}
+}
+
+func TestCreateApplicationRequestToModel_ShouldConvertToModel(t *testing.T) {
+	id := uuid.New()
+	companyID := uuid.New()
+	recruiterID := uuid.New()
+	jobTitle := "Job Title"
+	jobAdURL := "Job Ad URL"
+	country := "Some Country"
+	area := "Some Area"
+	weekdaysInOffice := 1
+	estimatedCycleTime := 2
+	estimatedCommuteTime := 3
+	applicationDate := time.Now().AddDate(0, 0, -1)
+
+	request := CreateApplicationRequest{
+		ID:                   &id,
+		CompanyID:            &companyID,
+		RecruiterID:          &recruiterID,
+		JobTitle:             &jobTitle,
+		JobAdURL:             &jobAdURL,
+		Country:              &country,
+		Area:                 &area,
+		RemoteStatusType:     models.RemoteStatusTypeHybrid,
+		WeekdaysInOffice:     &weekdaysInOffice,
+		EstimatedCycleTime:   &estimatedCycleTime,
+		EstimatedCommuteTime: &estimatedCommuteTime,
+		ApplicationDate:      &applicationDate,
+	}
+
+	model, err := request.ToModel()
+	assert.NoError(t, err)
+	assert.NotNil(t, model)
+
+	assert.Equal(t, id.String(), model.ID.String())
+	assert.Equal(t, companyID.String(), model.CompanyID.String())
+	assert.Equal(t, recruiterID.String(), model.RecruiterID.String())
+	assert.Equal(t, jobTitle, *model.JobTitle)
+	assert.Equal(t, jobAdURL, *model.JobAdURL)
+	assert.Equal(t, country, *model.Country)
+	assert.Equal(t, area, *model.Area)
+	assert.Equal(t, request.RemoteStatusType.String(), model.RemoteStatusType.String())
+	assert.Equal(t, weekdaysInOffice, *model.WeekdaysInOffice)
+	assert.Equal(t, estimatedCycleTime, *model.EstimatedCycleTime)
+	assert.Equal(t, estimatedCommuteTime, *model.EstimatedCommuteTime)
+
+	reqestApplicationDate := applicationDate.Format(time.RFC3339)
+	modelApplicationDate := model.ApplicationDate.Format(time.RFC3339)
+	assert.Equal(t, reqestApplicationDate, modelApplicationDate)
+}
+
+func TestCreateApplicationRequestToModel_ShouldConvertToModelWithNilValues(t *testing.T) {
+	recruiterID := uuid.New()
+	jobAdURL := "Job Ad URL"
+
+	request := CreateApplicationRequest{
+		RecruiterID:      &recruiterID,
+		JobAdURL:         &jobAdURL,
+		RemoteStatusType: RemoteStatusTypeRemote,
+	}
+
+	model, err := request.ToModel()
+	assert.NoError(t, err)
+	assert.NotNil(t, model)
+
+	assert.Nil(t, model.ID)
+	assert.Nil(t, model.CompanyID)
+	assert.Equal(t, request.RecruiterID, model.RecruiterID)
+	assert.Nil(t, model.JobTitle)
+	assert.Equal(t, jobAdURL, *model.JobAdURL)
+	assert.Nil(t, model.Country)
+	assert.Nil(t, model.Area)
+	assert.Equal(t, request.RemoteStatusType.String(), model.RemoteStatusType.String())
+	assert.Nil(t, model.WeekdaysInOffice)
+	assert.Nil(t, model.EstimatedCycleTime)
+	assert.Nil(t, model.EstimatedCommuteTime)
+	assert.Nil(t, model.ApplicationDate)
+}
+
+// -------- RemoteStatusType tests: --------
+
+func TestRemoteStatusTypeIsValid_ShouldReturnTrue(t *testing.T) {
+	hybrid := RemoteStatusType(RemoteStatusTypeHybrid)
+	assert.True(t, hybrid.IsValid())
+
+	office := RemoteStatusType(RemoteStatusTypeOffice)
+	assert.True(t, office.IsValid())
+
+	remote := RemoteStatusType(RemoteStatusTypeRemote)
+	assert.True(t, remote.IsValid())
+
+	unknown := RemoteStatusType(RemoteStatusTypeUnknown)
+	assert.True(t, unknown.IsValid())
+}
+
+func TestRemoteStatusTypeIsValid_ShouldReturnFalseOnInvalidRemoteStatusType(t *testing.T) {
+
+	empty := RemoteStatusType("")
+	assert.False(t, empty.IsValid())
+
+	nothing := RemoteStatusType("Nothing")
+	assert.False(t, nothing.IsValid())
+}
+
+func TestRemoteStatusTypeToModel_ShouldConvertToModel(t *testing.T) {
+	tests := []struct {
+		testName              string
+		applicationType       RemoteStatusType
+		modelRemoteStatusType models.RemoteStatusType
+	}{
+		{"hybrid", RemoteStatusTypeHybrid, models.RemoteStatusTypeHybrid},
+		{"office", RemoteStatusTypeOffice, models.RemoteStatusTypeOffice},
+		{"remote", RemoteStatusTypeRemote, models.RemoteStatusTypeRemote},
+		{"Unknown", RemoteStatusTypeUnknown, models.RemoteStatusTypeUnknown},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			modelRemoteStatusType, err := test.applicationType.ToModel()
+			assert.NoError(t, err)
+			assert.NotNil(t, modelRemoteStatusType)
+			assert.Equal(t, test.applicationType.String(), modelRemoteStatusType.String())
+		})
+	}
+}
+
+func TestRemoteStatusTypeToModel_ShouldReturnValidationErrorOnInvalidRemoteStatusType(t *testing.T) {
+	empty := RemoteStatusType("")
+	emptyModel, err := empty.ToModel()
+	assert.NotNil(t, emptyModel)
+	assert.NotNil(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+
+	assert.Equal(t, "", emptyModel.String())
+	assert.Equal(t, "validation error on field 'RemoteStatusType': invalid RemoteStatusType: ''", err.Error())
+
+	blah := RemoteStatusType("Blah")
+	blahModel, err := blah.ToModel()
+	assert.NotNil(t, blahModel)
+	assert.NotNil(t, err)
+
+	assert.True(t, errors.As(err, &validationErr))
+
+	assert.Equal(t, "", blahModel.String())
+	assert.Equal(t, "validation error on field 'RemoteStatusType': invalid RemoteStatusType: 'Blah'", err.Error())
+}
+
+func TestNewRemoteStatusType_ShouldConvertFromModel(t *testing.T) {
+	tests := []struct {
+		testName              string
+		modelRemoteStatusType models.RemoteStatusType
+		applicationType       RemoteStatusType
+	}{
+		{"hybrid", models.RemoteStatusTypeHybrid, RemoteStatusTypeHybrid},
+		{"office", models.RemoteStatusTypeOffice, RemoteStatusTypeOffice},
+		{"remote", models.RemoteStatusTypeRemote, RemoteStatusTypeRemote},
+		{"Unknown", models.RemoteStatusTypeUnknown, RemoteStatusTypeUnknown},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			applicationType, err := NewRemoteStatusType(&test.modelRemoteStatusType)
+			assert.NoError(t, err)
+			assert.NotNil(t, applicationType)
+			assert.Equal(t, test.applicationType.String(), applicationType.String())
+		})
+	}
+}
+
+func TestRemoteStatusTypeToModel_ShouldReturnInternalServiceErrorOnNilRemoteStatusType(t *testing.T) {
+	applicationType, err := NewRemoteStatusType(nil)
+	assert.NotNil(t, applicationType)
+	assert.NotNil(t, err)
+
+	var internalServiceErr *internalErrors.InternalServiceError
+	assert.True(t, errors.As(err, &internalServiceErr))
+
+	assert.Equal(t, "", applicationType.String())
+	assert.Equal(
+		t,
+		"internal service error: Error trying to convert internal RemoteStatusType to external RemoteStatusType.",
+		err.Error())
+}
+
+func TestRemoteStatusTypeToModel_ShouldReturnInternalServiceErrorOnInvalidRemoteStatusType(t *testing.T) {
+	emptyModel := models.RemoteStatusType("")
+	emptyApplication, err := NewRemoteStatusType(&emptyModel)
+	assert.NotNil(t, err)
+	assert.NotNil(t, emptyApplication)
+	assert.Equal(t, "", emptyApplication.String())
+
+	var internalServiceErr *internalErrors.InternalServiceError
+	assert.True(t, errors.As(err, &internalServiceErr))
+
+	assert.Equal(t, "", emptyApplication.String())
+
+	specialistModel := models.RemoteStatusType("specialist")
+	specialist, err := NewRemoteStatusType(&specialistModel)
+	assert.NotNil(t, err)
+	assert.NotNil(t, specialist)
+	assert.Equal(t, "", specialist.String())
+
+	assert.True(t, errors.As(err, &internalServiceErr))
+
+	assert.Equal(t,
+		"internal service error: Error converting internal RemoteStatusType to external RemoteStatusType: 'specialist'",
+		err.Error())
+}

--- a/internal/api/v1/responses/application_responses.go
+++ b/internal/api/v1/responses/application_responses.go
@@ -1,0 +1,60 @@
+package responses
+
+import (
+	"jobsearchtracker/internal/api/v1/requests"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type ApplicationResponse struct {
+	ID                   uuid.UUID                 `json:"id,omitempty"`
+	CompanyID            *uuid.UUID                `json:"company_id,omitempty"`
+	RecruiterID          *uuid.UUID                `json:"recruiter_id,omitempty"`
+	JobTitle             *string                   `json:"job_title,omitempty"`
+	JobAdURL             *string                   `json:"job_ad_url,omitempty"`
+	Country              *string                   `json:"country,omitempty"`
+	Area                 *string                   `json:"area,omitempty"`
+	RemoteStatusType     requests.RemoteStatusType `json:"remote_status_type"`
+	WeekdaysInOffice     *int                      `json:"weekdays_in_office,omitempty"`
+	EstimatedCycleTime   *int                      `json:"estimated_cycle_time,omitempty"`
+	EstimatedCommuteTime *int                      `json:"estimated_commute_time,omitempty"`
+	ApplicationDate      *time.Time                `json:"application_date,omitempty"`
+	CreatedDate          time.Time                 `json:"created_date"`
+	UpdatedDate          *time.Time                `json:"updated_date"`
+}
+
+// NewApplicationResponse can return InternalServerError
+func NewApplicationResponse(applicationModel *models.Application) (*ApplicationResponse, error) {
+	if applicationModel == nil {
+		slog.Error("responses.NewApplicationResponse: Application is nil")
+		return nil, internalErrors.NewInternalServiceError("Error building response: Application is nil")
+	}
+
+	remoteStatusType, err := requests.NewRemoteStatusType(&applicationModel.RemoteStatusType)
+	if err != nil {
+		return nil, err
+	}
+
+	applicationResponse := ApplicationResponse{
+		ID:                   applicationModel.ID,
+		CompanyID:            applicationModel.CompanyID,
+		RecruiterID:          applicationModel.RecruiterID,
+		JobTitle:             applicationModel.JobTitle,
+		JobAdURL:             applicationModel.JobAdURL,
+		Country:              applicationModel.Country,
+		Area:                 applicationModel.Area,
+		RemoteStatusType:     remoteStatusType,
+		WeekdaysInOffice:     applicationModel.WeekdaysInOffice,
+		EstimatedCycleTime:   applicationModel.EstimatedCycleTime,
+		EstimatedCommuteTime: applicationModel.EstimatedCommuteTime,
+		ApplicationDate:      applicationModel.ApplicationDate,
+		CreatedDate:          applicationModel.CreatedDate,
+		UpdatedDate:          applicationModel.UpdatedDate,
+	}
+
+	return &applicationResponse, nil
+}

--- a/internal/api/v1/responses/application_responses_test.go
+++ b/internal/api/v1/responses/application_responses_test.go
@@ -1,0 +1,159 @@
+package responses
+
+import (
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- NewApplicationResponse tests: --------
+
+func TestNewApplicationResponse_ShouldWork(t *testing.T) {
+	id := uuid.New()
+	companyID := uuid.New()
+	recruiterID := uuid.New()
+	jobTitle := "Job Title"
+	jobAdURL := "Job Ad URL"
+	country := "Job Country"
+	area := "Job Area"
+	weekdaysInOffice := 2
+	estimatedCycleTime := 30
+	estimatedCommuteTime := 40
+	applicationDate := time.Now().AddDate(0, 0, 1)
+	createdDate := time.Now().AddDate(0, 0, 2)
+	updatedDate := time.Now().AddDate(0, 0, 3)
+
+	model := models.Application{
+		ID:                   id,
+		CompanyID:            &companyID,
+		RecruiterID:          &recruiterID,
+		JobTitle:             &jobTitle,
+		JobAdURL:             &jobAdURL,
+		Country:              &country,
+		Area:                 &area,
+		RemoteStatusType:     models.RemoteStatusTypeHybrid,
+		WeekdaysInOffice:     &weekdaysInOffice,
+		EstimatedCycleTime:   &estimatedCycleTime,
+		EstimatedCommuteTime: &estimatedCommuteTime,
+		ApplicationDate:      &applicationDate,
+		CreatedDate:          createdDate,
+		UpdatedDate:          &updatedDate,
+	}
+
+	response, err := NewApplicationResponse(&model)
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+
+	assert.Equal(t, id, response.ID)
+	assert.Equal(t, companyID, *response.CompanyID)
+	assert.Equal(t, recruiterID, *response.RecruiterID)
+	assert.Equal(t, jobTitle, *response.JobTitle)
+	assert.Equal(t, jobAdURL, *response.JobAdURL)
+	assert.Equal(t, country, *response.Country)
+	assert.Equal(t, area, *response.Area)
+	assert.Equal(t, models.RemoteStatusTypeHybrid, response.RemoteStatusType.String())
+	assert.Equal(t, weekdaysInOffice, *response.WeekdaysInOffice)
+	assert.Equal(t, estimatedCycleTime, *response.EstimatedCycleTime)
+	assert.Equal(t, estimatedCommuteTime, *response.EstimatedCommuteTime)
+
+	applicationToInsertApplicationDate := applicationDate.Format(time.RFC3339)
+	insertedApplicationApplicationDate := response.ApplicationDate.Format(time.RFC3339)
+	assert.Equal(t, applicationToInsertApplicationDate, insertedApplicationApplicationDate)
+
+	applicationToInsertCreatedDate := createdDate.Format(time.RFC3339)
+	insertedApplicationCreatedDate := response.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, applicationToInsertCreatedDate, insertedApplicationCreatedDate)
+
+	applicationToInsertUpdatedDate := updatedDate.Format(time.RFC3339)
+	insertedApplicationUpdatedDate := response.UpdatedDate.Format(time.RFC3339)
+	assert.Equal(t, applicationToInsertUpdatedDate, insertedApplicationUpdatedDate)
+}
+
+func TestNewApplicationResponse_ShouldWorkWithOnlyRequiredFields(t *testing.T) {
+
+	companyID := uuid.New()
+	jobAdURL := "Job Ad URL"
+
+	model := models.Application{
+		ID:               uuid.New(),
+		CompanyID:        &companyID,
+		JobAdURL:         &jobAdURL,
+		RemoteStatusType: models.RemoteStatusTypeRemote,
+		CreatedDate:      time.Now().AddDate(0, 3, 0),
+	}
+
+	response, err := NewApplicationResponse(&model)
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+
+	assert.Equal(t, model.ID.String(), response.ID.String())
+	assert.Equal(t, model.CompanyID, response.CompanyID)
+	assert.Nil(t, model.RecruiterID)
+	assert.Nil(t, response.JobTitle)
+	assert.Equal(t, model.JobAdURL, response.JobAdURL)
+	assert.Nil(t, response.Country)
+	assert.Nil(t, response.Area)
+	assert.Equal(t, model.RemoteStatusType.String(), response.RemoteStatusType.String())
+	assert.Nil(t, response.WeekdaysInOffice)
+	assert.Nil(t, response.EstimatedCycleTime)
+	assert.Nil(t, response.EstimatedCommuteTime)
+	assert.Nil(t, response.ApplicationDate)
+	assert.Equal(t, model.CreatedDate, response.CreatedDate)
+	assert.Nil(t, response.UpdatedDate)
+}
+
+func TestNewApplicationResponse_ShouldReturnInternalServiceErrorIfModelIsNil(t *testing.T) {
+	nilModel, err := NewApplicationResponse(nil)
+	assert.Nil(t, nilModel)
+	assert.NotNil(t, err)
+
+	var internalServiceErr *internalErrors.InternalServiceError
+	assert.True(t, errors.As(err, &internalServiceErr))
+
+	assert.Equal(t, err.Error(), "internal service error: Error building response: Application is nil")
+}
+
+func TestNewApplicationResponse_ShouldReturnInternalServiceErrorIfRemoteStatusTypeIsInvalid(t *testing.T) {
+	recruiterID := uuid.New()
+	JobAdURL := "Job Ad URL"
+
+	emptyRemoteStatusType := models.Application{
+		ID:               uuid.New(),
+		RecruiterID:      &recruiterID,
+		JobAdURL:         &JobAdURL,
+		RemoteStatusType: "",
+		CreatedDate:      time.Now().AddDate(0, 0, 16),
+	}
+	emptyResponse, err := NewApplicationResponse(&emptyRemoteStatusType)
+	assert.Nil(t, emptyResponse)
+	assert.NotNil(t, err)
+
+	var internalServiceErr *internalErrors.InternalServiceError
+	assert.True(t, errors.As(err, &internalServiceErr))
+
+	assert.Equal(t,
+		"internal service error: Error converting internal RemoteStatusType to external RemoteStatusType: ''",
+		err.Error())
+
+	invalidRemoteStatusType := models.Application{
+		ID:               uuid.New(),
+		RecruiterID:      &recruiterID,
+		JobAdURL:         &JobAdURL,
+		RemoteStatusType: "Blah",
+		CreatedDate:      time.Now().AddDate(0, 0, 16),
+	}
+	invalidResponse, err := NewApplicationResponse(&invalidRemoteStatusType)
+	assert.Nil(t, invalidResponse)
+	assert.NotNil(t, err)
+
+	assert.True(t, errors.As(err, &internalServiceErr))
+
+	assert.Equal(t,
+		"internal service error: Error converting internal RemoteStatusType to external RemoteStatusType: 'Blah'",
+		err.Error())
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -56,7 +56,7 @@ func (database *FileDatabase) buildAndEnsureFilePath(config *config.Config) stri
 		}
 	}
 
-	dbFilePath += config.DatabaseFileName
+	dbFilePath += config.DatabaseFileName + "?_pragma=foreign_keys(1)"
 	return dbFilePath
 }
 
@@ -67,7 +67,7 @@ func NewInMemoryDatabase() Database {
 }
 
 func (database *InMemoryDatabase) Connect(_ *config.Config) (*sql.DB, error) {
-	db, err := sql.Open("sqlite", ":memory:")
+	db, err := sql.Open("sqlite", ":memory:?_pragma=foreign_keys(1)")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/models/application.go
+++ b/internal/models/application.go
@@ -1,0 +1,117 @@
+package models
+
+import (
+	"jobsearchtracker/internal/errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Application struct {
+	ID                   uuid.UUID
+	CompanyID            *uuid.UUID
+	RecruiterID          *uuid.UUID
+	JobTitle             *string
+	JobAdURL             *string
+	Country              *string
+	Area                 *string
+	RemoteStatusType     RemoteStatusType
+	WeekdaysInOffice     *int
+	EstimatedCycleTime   *int
+	EstimatedCommuteTime *int
+	ApplicationDate      *time.Time
+	CreatedDate          time.Time
+	UpdatedDate          *time.Time
+}
+
+type CreateApplication struct {
+	ID                   *uuid.UUID
+	CompanyID            *uuid.UUID
+	RecruiterID          *uuid.UUID
+	JobTitle             *string
+	JobAdURL             *string
+	Country              *string
+	Area                 *string
+	RemoteStatusType     RemoteStatusType
+	WeekdaysInOffice     *int
+	EstimatedCycleTime   *int
+	EstimatedCommuteTime *int
+	ApplicationDate      *time.Time
+	CreatedDate          *time.Time
+	UpdatedDate          *time.Time
+}
+
+func (application *CreateApplication) Validate() error {
+
+	if application.CompanyID != nil {
+		err := uuid.Validate(application.CompanyID.String())
+		if err != nil {
+			return errors.NewValidationError(nil, "CompanyID is invalid")
+		}
+	}
+
+	if application.RecruiterID != nil {
+		err := uuid.Validate(application.RecruiterID.String())
+		if err != nil {
+			return errors.NewValidationError(nil, "RecruiterID is invalid")
+		}
+	}
+
+	if (application.CompanyID == nil || *application.CompanyID == uuid.Nil) &&
+		(application.RecruiterID == nil || *application.RecruiterID == uuid.Nil) {
+		return errors.NewValidationError(nil, "CompanyID and RecruiterID cannot both be empty")
+	}
+
+	if application.JobTitle != nil && *application.JobTitle == "" {
+		return errors.NewValidationError(nil, "JobTitle is empty")
+	}
+
+	if application.JobAdURL != nil && *application.JobAdURL == "" {
+		return errors.NewValidationError(nil, "JobAdURL is empty")
+	}
+
+	if application.JobTitle == nil && application.JobAdURL == nil {
+		return errors.NewValidationError(nil, "JobTitle and JobAdURL cannot be both be nil")
+	}
+
+	if !application.RemoteStatusType.IsValid() {
+		return errors.NewValidationError(nil, "remoteStatusType is invalid")
+	}
+
+	if application.ApplicationDate != nil && application.ApplicationDate.IsZero() {
+		updatedDate := "ApplicationDate"
+		return errors.NewValidationError(
+			&updatedDate,
+			"ApplicationDate is zero. It should either be 'nil' or a recent date. Given that this is an insert, it is recommended to use nil")
+	}
+
+	if application.UpdatedDate != nil && application.UpdatedDate.IsZero() {
+		updatedDate := "UpdatedDate"
+		return errors.NewValidationError(
+			&updatedDate,
+			"UpdatedDate is zero. It should either be 'nil' or a recent date. Given that this is an insert, it is recommended to use nil")
+	}
+
+	return nil
+}
+
+type RemoteStatusType string
+
+const (
+	RemoteStatusTypeHybrid  = "hybrid"
+	RemoteStatusTypeOffice  = "office"
+	RemoteStatusTypeRemote  = "remote"
+	RemoteStatusTypeUnknown = "unknown"
+)
+
+func (remoteStatusType RemoteStatusType) IsValid() bool {
+	switch remoteStatusType {
+	case RemoteStatusTypeHybrid, RemoteStatusTypeOffice, RemoteStatusTypeRemote, RemoteStatusTypeUnknown:
+		return true
+	}
+	return false
+}
+
+func (remoteStatusType RemoteStatusType) String() string {
+	return string(remoteStatusType)
+}

--- a/internal/models/application_test.go
+++ b/internal/models/application_test.go
@@ -1,0 +1,232 @@
+package models
+
+import (
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- CreateApplication.Validate tests: --------
+func TestCreateApplicationValidate_ShouldReturnNilIfApplicationIsValid(t *testing.T) {
+
+	id := uuid.New()
+	companyID := uuid.New()
+	recruiterID := uuid.New()
+	jobTitle := "Job1 Title"
+	jobAdUrl := "Job1 Ad URL"
+	country := "Job 1 Country"
+	area := "Job 1 Area"
+	weekdaysInOffice := 2
+	estimatedCycleTime := 30
+	estimatedCommuteTime := 40
+	applicationDate := time.Now().AddDate(0, 0, 1)
+	createdDate := time.Now().AddDate(0, 0, 2)
+	updatedDate := time.Now().AddDate(0, 0, 3)
+
+	application := CreateApplication{
+		ID:                   &id,
+		CompanyID:            &companyID,
+		RecruiterID:          &recruiterID,
+		JobTitle:             &jobTitle,
+		JobAdURL:             &jobAdUrl,
+		Country:              &country,
+		Area:                 &area,
+		RemoteStatusType:     RemoteStatusTypeHybrid,
+		WeekdaysInOffice:     &weekdaysInOffice,
+		EstimatedCycleTime:   &estimatedCycleTime,
+		EstimatedCommuteTime: &estimatedCommuteTime,
+		ApplicationDate:      &applicationDate,
+		CreatedDate:          &createdDate,
+		UpdatedDate:          &updatedDate,
+	}
+	err := application.Validate()
+	assert.NoError(t, err)
+}
+
+func TestCreateApplicationValidate_ShouldReturnNilWithOnlyRequiredFields(t *testing.T) {
+
+	recruiterID := uuid.New()
+	jobTitle := "Job1 Title"
+
+	application := CreateApplication{
+		RecruiterID:      &recruiterID,
+		JobTitle:         &jobTitle,
+		RemoteStatusType: RemoteStatusTypeHybrid,
+	}
+	err := application.Validate()
+	assert.NoError(t, err)
+}
+
+func TestCreateApplicationValidate_ShouldReturnValidationErrorIfCompanyIDAndRecruiterIDAreNull(t *testing.T) {
+	tests := []struct {
+		testName    string
+		companyId   *uuid.UUID
+		recruiterId *uuid.UUID
+	}{
+		{
+			testName:    "companyId is nil and recruiterId is nil",
+			companyId:   nil,
+			recruiterId: nil,
+		},
+		{
+			testName:    "companyId is uuid.Nil and recruiterId is nil",
+			companyId:   &uuid.Nil,
+			recruiterId: nil,
+		},
+		{
+			testName:    "companyId is nil and recruiterId is uuid.Nil",
+			companyId:   nil,
+			recruiterId: &uuid.Nil,
+		},
+		{
+			testName:    "companyId is uuid.Nil and recruiterId is uuid.Nil",
+			companyId:   &uuid.Nil,
+			recruiterId: &uuid.Nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			application := CreateApplication{
+				CompanyID:   test.companyId,
+				RecruiterID: test.recruiterId,
+			}
+			err := application.Validate()
+			assert.Error(t, err)
+
+			var validationErr *internalErrors.ValidationError
+			assert.True(t, errors.As(err, &validationErr))
+			assert.Equal(t, "validation error: CompanyID and RecruiterID cannot both be empty", err.Error())
+		})
+	}
+}
+
+func TestCreateApplicationValidate_ShouldReturnValidationErrorIfJobTitleIsEmpty(t *testing.T) {
+	companyID := uuid.New()
+	jobTitle := ""
+	application := CreateApplication{
+		CompanyID: &companyID,
+		JobTitle:  &jobTitle,
+	}
+	err := application.Validate()
+	assert.Error(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: JobTitle is empty", validationErr.Error())
+}
+
+func TestCreateApplicationValidate_ShouldReturnValidationErrorIfJobAdUrlIsEmpty(t *testing.T) {
+	companyID := uuid.New()
+	JobAdUrl := ""
+	application := CreateApplication{
+		CompanyID: &companyID,
+		JobAdURL:  &JobAdUrl,
+	}
+	err := application.Validate()
+	assert.Error(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: JobAdURL is empty", validationErr.Error())
+}
+
+func TestCreateApplicationValidate_ShouldReturnValidationErrorIfJobTitleIsEmptyAndJobAdUrlIsNil(t *testing.T) {
+	companyID := uuid.New()
+	application := CreateApplication{
+		CompanyID: &companyID,
+		JobTitle:  nil,
+		JobAdURL:  nil,
+	}
+	err := application.Validate()
+	assert.Error(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: JobTitle and JobAdURL cannot be both be nil", validationErr.Error())
+}
+
+func TestCreateApplicationValidate_ShouldReturnValidationErrorIfRemoteStatusIsInvalid(t *testing.T) {
+	companyID := uuid.New()
+	jobTitle := "not important"
+	var fakeRemoteStatusType RemoteStatusType = "something that should never happen"
+	application := CreateApplication{
+		CompanyID:        &companyID,
+		JobTitle:         &jobTitle,
+		RemoteStatusType: fakeRemoteStatusType,
+	}
+	err := application.Validate()
+	assert.Error(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: remoteStatusType is invalid", validationErr.Error())
+}
+
+func TestCreateApplicationValidate_ShouldReturnValidationErrorOnUnsetApplicationDate(t *testing.T) {
+	companyID := uuid.New()
+	jobTitle := "not important"
+	application := CreateApplication{
+		CompanyID:        &companyID,
+		JobTitle:         &jobTitle,
+		RemoteStatusType: RemoteStatusTypeOffice,
+		ApplicationDate:  &time.Time{},
+	}
+	err := application.Validate()
+	assert.Error(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(
+		t,
+		"validation error on field 'ApplicationDate': ApplicationDate is zero. It should either be 'nil' or a recent date. Given that this is an insert, it is recommended to use nil",
+		validationErr.Error())
+}
+
+func TestCreateApplicationValidate_ShouldReturnValidationErrorOnUnsetUpdatedDate(t *testing.T) {
+	companyID := uuid.New()
+	jobTitle := "not important"
+	application := CreateApplication{
+		CompanyID:        &companyID,
+		JobTitle:         &jobTitle,
+		RemoteStatusType: RemoteStatusTypeUnknown,
+		UpdatedDate:      &time.Time{},
+	}
+	err := application.Validate()
+	assert.Error(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(
+		t,
+		"validation error on field 'UpdatedDate': UpdatedDate is zero. It should either be 'nil' or a recent date. Given that this is an insert, it is recommended to use nil",
+		validationErr.Error())
+}
+
+// -------- RemoteStatusType.IsValid tests: --------
+
+func TestRemoteStatusTypesValid_ShouldReturnTrue(t *testing.T) {
+	hybrid := RemoteStatusType(RemoteStatusTypeHybrid)
+	assert.True(t, hybrid.IsValid())
+
+	office := RemoteStatusType(RemoteStatusTypeOffice)
+	assert.True(t, office.IsValid())
+
+	remote := RemoteStatusType(RemoteStatusTypeRemote)
+	assert.True(t, remote.IsValid())
+
+	unknown := RemoteStatusType(RemoteStatusTypeUnknown)
+	assert.True(t, unknown.IsValid())
+}
+
+func TestRemoteStatusTypeIsValid_ShouldReturnFalseOnInvalidRemoteStatusType(t *testing.T) {
+	empty := RemoteStatusType("")
+	assert.False(t, empty.IsValid())
+
+	spammer := RemoteStatusType("offshore")
+	assert.False(t, spammer.IsValid())
+}

--- a/internal/repositories/application_repository.go
+++ b/internal/repositories/application_repository.go
@@ -1,0 +1,200 @@
+package repositories
+
+import (
+	"database/sql"
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type ApplicationRepository struct {
+	database *sql.DB
+}
+
+func NewApplicationRepository(database *sql.DB) *ApplicationRepository {
+	return &ApplicationRepository{database: database}
+}
+
+// Create can return ConflictError, InternalServiceError, ValidationError
+func (repository *ApplicationRepository) Create(application *models.CreateApplication) (*models.Application, error) {
+	sqlInsert := "INSERT INTO application (id, company_id, recruiter_id, job_title, job_ad_url, country, area, " +
+		"remote_status_type, weekdays_in_office, estimated_cycle_time, estimated_commute_time, application_date, " +
+		"created_date, updated_date)" +
+		"VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" +
+		"RETURNING id, company_id, recruiter_id, job_title, job_ad_url, country, area, remote_status_type, " +
+		"weekdays_in_office, estimated_cycle_time, estimated_commute_time, application_date, created_date, " +
+		"updated_date"
+
+	var applicationID uuid.UUID
+	if application.ID != nil {
+		applicationID = *application.ID
+	} else {
+		applicationID = uuid.New()
+	}
+
+	var applicationDate, createdDate, updatedDate interface{}
+
+	if application.ApplicationDate != nil {
+		applicationDate = application.ApplicationDate.Format(time.RFC3339)
+	}
+
+	if application.CreatedDate != nil {
+		createdDate = application.CreatedDate.Format(time.RFC3339)
+	} else {
+		createdDate = time.Now()
+	}
+
+	if application.UpdatedDate != nil {
+		updatedDate = application.UpdatedDate.Format(time.RFC3339)
+	}
+
+	row := repository.database.QueryRow(
+		sqlInsert,
+		applicationID,
+		application.CompanyID,
+		application.RecruiterID,
+		application.JobTitle,
+		application.JobAdURL,
+		application.Country,
+		application.Area,
+		application.RemoteStatusType,
+		application.WeekdaysInOffice,
+		application.EstimatedCycleTime,
+		application.EstimatedCommuteTime,
+		applicationDate,
+		createdDate,
+		updatedDate,
+	)
+
+	result, err := repository.mapRow(row, "Create", &applicationID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			slog.Info("application_repository.Create: No result found for ID",
+				"ID", applicationID,
+				"error", err.Error())
+		} else if err.Error() == "constraint failed: CHECK constraint failed: company_reference_not_null (275)" {
+			slog.Error("application_repository.Create: CHECK constraint failed: company_reference_not_null")
+			return nil, internalErrors.NewValidationError(nil, "CompanyID and RecruiterID cannot both be empty")
+		} else if err.Error() == "constraint failed: CHECK constraint failed: job_title_job_url_not_null (275)" {
+			slog.Error("application_repository.Create: CHECK constraint failed: job_title_job_url_not_null")
+			return nil, internalErrors.NewValidationError(nil, "JobTitle and JobAdURL cannot both be empty")
+		} else if err.Error() == "constraint failed: FOREIGN KEY constraint failed (787)" {
+			// TODO: Use foreign key constraint names (in 0003_add_application.up.sql) once modernc.org/sqlite
+			// supports it.
+			slog.Info("application_repository.Create: FOREIGN KEY constraint failed (787)")
+			return nil, internalErrors.NewValidationError(nil, "Foreign key does not exist")
+		}
+		return nil, err
+	}
+
+	return result, err
+}
+
+// GetById can return InternalServiceError, NotFoundError, ValidationError
+func (repository *ApplicationRepository) GetById(id *uuid.UUID) (*models.Application, error) {
+	if id == nil {
+		slog.Info("application_repository.GetById: ID is nil")
+		return nil, internalErrors.NewValidationError(nil, "ID is nil")
+	}
+
+	sqlSelect := "SELECT id, company_id, recruiter_id, job_title, job_ad_url, country, area, remote_status_type, " +
+		"weekdays_in_office, estimated_cycle_time, estimated_commute_time, application_date, created_date, " +
+		"updated_date " +
+		"FROM application " +
+		"WHERE id = ?"
+
+	row := repository.database.QueryRow(sqlSelect, id)
+
+	// can return ConflictError, InternalServiceError
+	result, err := repository.mapRow(row, "GetById", id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			slog.Info("application_repository.GetById: No result found for ID", "ID", id, "error", err.Error())
+			return nil, internalErrors.NewNotFoundError("ID: '" + id.String() + "'")
+		}
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (repository *ApplicationRepository) mapRow(
+	scanner interface{ Scan(...interface{}) error }, methodName string, ID *uuid.UUID) (*models.Application, error) {
+
+	var result models.Application
+	var applicationDate, createdDate, updatedDate sql.NullString
+
+	err := scanner.Scan(
+		&result.ID,
+		&result.CompanyID,
+		&result.RecruiterID,
+		&result.JobTitle,
+		&result.JobAdURL,
+		&result.Country,
+		&result.Area,
+		&result.RemoteStatusType,
+		&result.WeekdaysInOffice,
+		&result.EstimatedCycleTime,
+		&result.EstimatedCommuteTime,
+		&applicationDate,
+		&createdDate,
+		&updatedDate,
+	)
+
+	if err != nil {
+		if err.Error() == "constraint failed: UNIQUE constraint failed: application.id (1555)" {
+			var IDString string
+			if ID != nil {
+				IDString = ID.String()
+			} else {
+				IDString = "[not set]"
+			}
+			slog.Info(
+				"application_repository.createApplication: UNIQUE constraint failed",
+				"ID", IDString)
+			return nil, internalErrors.NewConflictError(
+				"ID already exists in database: '" + IDString + "'")
+		}
+		return nil, err
+	}
+
+	if applicationDate.Valid {
+		timestamp, err := time.Parse(time.RFC3339, applicationDate.String)
+		if err != nil {
+			slog.Error(
+				"application_repository."+methodName+": Error parsing applicationDate",
+				"applicationDate", applicationDate,
+				"error", err.Error())
+			return nil, internalErrors.NewInternalServiceError("Error parsing applicationDate: " + err.Error())
+		}
+		result.ApplicationDate = &timestamp
+	}
+
+	if createdDate.Valid {
+		timestamp, err := time.Parse(time.RFC3339, createdDate.String)
+		if err != nil {
+			slog.Error("application_repository."+methodName+": Error parsing createdDate",
+				"createdDate", createdDate,
+				"error", err.Error())
+			return nil, internalErrors.NewInternalServiceError("Error parsing createdDate: " + err.Error())
+		}
+		result.CreatedDate = timestamp
+	}
+
+	if updatedDate.Valid {
+		timestamp, err := time.Parse(time.RFC3339, updatedDate.String)
+		if err != nil {
+			slog.Error("application_repository."+methodName+": Error parsing updatedDate",
+				"updatedDate", updatedDate,
+				"error", err.Error())
+			return nil, internalErrors.NewInternalServiceError("Error parsing updatedDate: " + err.Error())
+		}
+		result.UpdatedDate = &timestamp
+	}
+
+	return &result, nil
+}

--- a/internal/repositories/application_repository_integration_test.go
+++ b/internal/repositories/application_repository_integration_test.go
@@ -1,0 +1,330 @@
+package repositories_test
+
+import (
+	"errors"
+	configPackage "jobsearchtracker/internal/config"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/repositories"
+	"jobsearchtracker/internal/testutil/dependencyinjection"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupApplicationRepository(t *testing.T) (*repositories.ApplicationRepository, *repositories.CompanyRepository) {
+	config := &configPackage.Config{
+		DatabaseMigrationsPath:               "../../migrations",
+		IsDatabaseMigrationsPathAbsolutePath: false,
+	}
+
+	container := dependencyinjection.SetupApplicationRepositoryTestContainer(t, *config)
+
+	var applicationRepository *repositories.ApplicationRepository
+	err := container.Invoke(func(repository *repositories.ApplicationRepository) {
+		applicationRepository = repository
+	})
+	assert.NoError(t, err)
+
+	var companyRepository *repositories.CompanyRepository
+	err = container.Invoke(func(repository *repositories.CompanyRepository) {
+		companyRepository = repository
+	})
+	assert.NoError(t, err)
+
+	return applicationRepository, companyRepository
+}
+
+// -------- Create tests: --------
+
+func TestCreate_ShouldInsertAndReturnApplication(t *testing.T) {
+	applicationRepository, companyRepository := setupApplicationRepository(t)
+
+	companyID := createCompany(t, companyRepository)
+	recruiterID := createCompany(t, companyRepository)
+
+	id := uuid.New()
+	jobTitle := "Job Title"
+	jobAdURL := "Job Ad URL"
+	country := "Some Country"
+	area := "Some Area"
+	weekdaysInOffice := 1
+	estimatedCycleTime := 2
+	estimatedCommuteTime := 3
+	applicationDate := time.Now().AddDate(0, 0, -1)
+	createdDate := time.Now().AddDate(0, 0, -2)
+	updatedDate := time.Now().AddDate(0, 0, -3)
+
+	application := models.CreateApplication{
+		ID:                   &id,
+		CompanyID:            companyID,
+		RecruiterID:          recruiterID,
+		JobTitle:             &jobTitle,
+		JobAdURL:             &jobAdURL,
+		Country:              &country,
+		Area:                 &area,
+		RemoteStatusType:     models.RemoteStatusTypeHybrid,
+		WeekdaysInOffice:     &weekdaysInOffice,
+		EstimatedCycleTime:   &estimatedCycleTime,
+		EstimatedCommuteTime: &estimatedCommuteTime,
+		ApplicationDate:      &applicationDate,
+		CreatedDate:          &createdDate,
+		UpdatedDate:          &updatedDate,
+	}
+
+	insertedApplication, err := applicationRepository.Create(&application)
+	assert.NoError(t, err)
+	assert.NotNil(t, insertedApplication)
+
+	assert.Equal(t, id, insertedApplication.ID)
+	assert.Equal(t, companyID, insertedApplication.CompanyID)
+	assert.Equal(t, recruiterID, insertedApplication.RecruiterID)
+	assert.Equal(t, jobTitle, *insertedApplication.JobTitle)
+	assert.Equal(t, jobAdURL, *insertedApplication.JobAdURL)
+	assert.Equal(t, country, *insertedApplication.Country)
+	assert.Equal(t, area, *insertedApplication.Area)
+	assert.Equal(t, models.RemoteStatusTypeHybrid, insertedApplication.RemoteStatusType.String())
+	assert.Equal(t, weekdaysInOffice, *insertedApplication.WeekdaysInOffice)
+	assert.Equal(t, estimatedCycleTime, *insertedApplication.EstimatedCycleTime)
+	assert.Equal(t, estimatedCommuteTime, *insertedApplication.EstimatedCommuteTime)
+
+	applicationToInsertApplicationDate := applicationDate.Format(time.RFC3339)
+	insertedApplicationApplicationDate := insertedApplication.ApplicationDate.Format(time.RFC3339)
+	assert.Equal(t, applicationToInsertApplicationDate, insertedApplicationApplicationDate)
+
+	applicationToInsertCreatedDate := createdDate.Format(time.RFC3339)
+	insertedApplicationCreatedDate := insertedApplication.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, applicationToInsertCreatedDate, insertedApplicationCreatedDate)
+
+	applicationToInsertUpdatedDate := updatedDate.Format(time.RFC3339)
+	insertedApplicationUpdatedDate := insertedApplication.UpdatedDate.Format(time.RFC3339)
+	assert.Equal(t, applicationToInsertUpdatedDate, insertedApplicationUpdatedDate)
+}
+
+func TestCreate_ShouldInsertAndReturnWithMinimumRequiredFields(t *testing.T) {
+	applicationRepository, companyRepository := setupApplicationRepository(t)
+
+	companyID := createCompany(t, companyRepository)
+
+	jobAdURL := "Job Ad URL"
+	application := models.CreateApplication{
+		CompanyID:        companyID,
+		JobAdURL:         &jobAdURL,
+		RemoteStatusType: models.RemoteStatusTypeHybrid,
+	}
+
+	createdDateApproximation := time.Now().Format(time.RFC3339)
+	insertedApplication, err := applicationRepository.Create(&application)
+	assert.NoError(t, err)
+	assert.NotNil(t, insertedApplication)
+
+	assert.NotNil(t, insertedApplication.ID)
+	assert.Equal(t, companyID, insertedApplication.CompanyID)
+	assert.Nil(t, insertedApplication.RecruiterID)
+	assert.Nil(t, insertedApplication.JobTitle)
+	assert.Equal(t, jobAdURL, *insertedApplication.JobAdURL)
+	assert.Nil(t, insertedApplication.Country)
+	assert.Nil(t, insertedApplication.Area)
+	assert.Equal(t, models.RemoteStatusTypeHybrid, insertedApplication.RemoteStatusType.String())
+	assert.Nil(t, insertedApplication.WeekdaysInOffice)
+	assert.Nil(t, insertedApplication.EstimatedCycleTime)
+	assert.Nil(t, insertedApplication.EstimatedCommuteTime)
+	assert.Nil(t, insertedApplication.ApplicationDate)
+
+	insertedCompanyCreatedDate := insertedApplication.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, createdDateApproximation, insertedCompanyCreatedDate)
+	assert.Nil(t, insertedApplication.UpdatedDate)
+}
+
+func TestCreate_ShouldReturnErrorIfCompanyIDAndRecruiterIDIsNil(t *testing.T) {
+	applicationRepository, _ := setupApplicationRepository(t)
+
+	jobTitle := "JobTitle"
+	createApplication := models.CreateApplication{
+		CompanyID:        nil,
+		RecruiterID:      nil,
+		JobTitle:         &jobTitle,
+		RemoteStatusType: models.RemoteStatusTypeHybrid,
+	}
+
+	application, err := applicationRepository.Create(&createApplication)
+	assert.Nil(t, application)
+	assert.Error(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: CompanyID and RecruiterID cannot both be empty", err.Error())
+}
+
+func TestCreate_ShouldReturnErrorIfCompanyIDIsNotInCompany(t *testing.T) {
+	applicationRepository, _ := setupApplicationRepository(t)
+
+	companyID := uuid.New()
+	jobTitle := "JobTitle"
+	createApplication := models.CreateApplication{
+		CompanyID:        &companyID,
+		RecruiterID:      nil,
+		JobTitle:         &jobTitle,
+		RemoteStatusType: models.RemoteStatusTypeHybrid,
+	}
+
+	application, err := applicationRepository.Create(&createApplication)
+	assert.Nil(t, application)
+	assert.Error(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: Foreign key does not exist", err.Error())
+}
+
+func TestCreate_ShouldReturnErrorIfRecruiterIDIsNotInCompany(t *testing.T) {
+	applicationRepository, _ := setupApplicationRepository(t)
+
+	recruiterID := uuid.New()
+	jobTitle := "JobTitle"
+	createApplication := models.CreateApplication{
+		CompanyID:        nil,
+		RecruiterID:      &recruiterID,
+		JobTitle:         &jobTitle,
+		RemoteStatusType: models.RemoteStatusTypeHybrid,
+	}
+
+	application, err := applicationRepository.Create(&createApplication)
+	assert.Nil(t, application)
+	assert.Error(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: Foreign key does not exist", err.Error())
+}
+
+func TestCreate_ShouldReturnErrorIfJobTitleAndJobAdURLIsNil(t *testing.T) {
+	applicationRepository, companyRepository := setupApplicationRepository(t)
+
+	companyID := createCompany(t, companyRepository)
+
+	createApplication := models.CreateApplication{
+		CompanyID:        companyID,
+		JobTitle:         nil,
+		JobAdURL:         nil,
+		RemoteStatusType: models.RemoteStatusTypeOffice,
+	}
+
+	application, err := applicationRepository.Create(&createApplication)
+	assert.Nil(t, application)
+	assert.Error(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: JobTitle and JobAdURL cannot both be empty", err.Error())
+
+}
+
+// -------- GetById tests: --------
+
+func TestGetById_ShouldGetApplication(t *testing.T) {
+	applicationRepository, companyRepository := setupApplicationRepository(t)
+
+	companyID := createCompany(t, companyRepository)
+	recruiterID := createCompany(t, companyRepository)
+
+	id := uuid.New()
+	jobTitle := "Job Title"
+	jobAdURL := "Job Ad URL"
+	country := "Country"
+	area := "Area"
+	weekdaysInOffice := 1
+	estimatedCycleTime := 2
+	estimatedCommuteTime := 3
+
+	applicationDate := time.Now().AddDate(0, 0, -1)
+	createdDate := time.Now().AddDate(0, 0, -2)
+	updatedDate := time.Now().AddDate(0, 0, -3)
+
+	applicationToInsert := models.CreateApplication{
+		ID:                   &id,
+		CompanyID:            companyID,
+		RecruiterID:          recruiterID,
+		JobTitle:             &jobTitle,
+		JobAdURL:             &jobAdURL,
+		Country:              &country,
+		Area:                 &area,
+		RemoteStatusType:     models.RemoteStatusTypeOffice,
+		WeekdaysInOffice:     &weekdaysInOffice,
+		EstimatedCycleTime:   &estimatedCycleTime,
+		EstimatedCommuteTime: &estimatedCommuteTime,
+		ApplicationDate:      &applicationDate,
+		CreatedDate:          &createdDate,
+		UpdatedDate:          &updatedDate,
+	}
+
+	insertedApplication, err := applicationRepository.Create(&applicationToInsert)
+	assert.NoError(t, err)
+	assert.NotNil(t, insertedApplication)
+
+	retrievedApplication, err := applicationRepository.GetById(&id)
+	assert.NoError(t, err)
+	assert.NotNil(t, retrievedApplication)
+
+	assert.Equal(t, id, retrievedApplication.ID)
+	assert.Equal(t, companyID, retrievedApplication.CompanyID)
+	assert.Equal(t, recruiterID, retrievedApplication.RecruiterID)
+	assert.Equal(t, jobAdURL, *retrievedApplication.JobAdURL)
+	assert.Equal(t, country, *retrievedApplication.Country)
+	assert.Equal(t, area, *retrievedApplication.Area)
+	assert.Equal(t, applicationToInsert.RemoteStatusType, retrievedApplication.RemoteStatusType)
+	assert.Equal(t, weekdaysInOffice, *retrievedApplication.WeekdaysInOffice)
+	assert.Equal(t, estimatedCycleTime, *retrievedApplication.EstimatedCycleTime)
+	assert.Equal(t, estimatedCommuteTime, *retrievedApplication.EstimatedCommuteTime)
+
+	retrievedApplicationLastContact := retrievedApplication.ApplicationDate.Format(time.RFC3339)
+	applicationToInsertLastContact := applicationToInsert.ApplicationDate.Format(time.RFC3339)
+	assert.Equal(t, applicationToInsertLastContact, retrievedApplicationLastContact)
+
+	retrievedApplicationCreatedDate := retrievedApplication.CreatedDate.Format(time.RFC3339)
+	applicationToInsertCreatedDate := applicationToInsert.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, applicationToInsertCreatedDate, retrievedApplicationCreatedDate)
+
+	retrievedApplicationUpdatedDate := retrievedApplication.UpdatedDate.Format(time.RFC3339)
+	applicationToInsertUpdatedDate := applicationToInsert.UpdatedDate.Format(time.RFC3339)
+	assert.Equal(t, applicationToInsertUpdatedDate, retrievedApplicationUpdatedDate)
+}
+
+func TestGetById_ShouldReturnErrorIfApplicationIDIsNil(t *testing.T) {
+	applicationRepository, _ := setupApplicationRepository(t)
+
+	response, err := applicationRepository.GetById(nil)
+	assert.Nil(t, response)
+	assert.NotNil(t, err)
+	assert.Equal(t, "validation error: ID is nil", err.Error())
+}
+
+func TestGetById_ShouldReturnErrorIfApplicationIDDoesNotExist(t *testing.T) {
+	applicationRepository, _ := setupApplicationRepository(t)
+
+	id := uuid.New()
+
+	response, err := applicationRepository.GetById(&id)
+	assert.Nil(t, response, "response should be nil")
+	assert.NotNil(t, err, err.Error(), "Wrong error returned")
+	assert.Equal(t, "error: object not found: ID: '"+id.String()+"'", err.Error())
+}
+
+// -------- Test helpers: --------
+
+func createCompany(t *testing.T, companyRepository *repositories.CompanyRepository) *uuid.UUID {
+
+	id := uuid.New()
+	company := models.CreateCompany{
+		ID:          &id,
+		Name:        "Example Company Name",
+		CompanyType: models.CompanyTypeEmployer,
+	}
+
+	insertedCompany, err := companyRepository.Create(&company)
+	assert.NoError(t, err)
+
+	return &insertedCompany.ID
+}

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -1,0 +1,85 @@
+package services
+
+import (
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/repositories"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type ApplicationService struct {
+	applicationRepository *repositories.ApplicationRepository
+}
+
+func NewApplicationService(applicationRepository *repositories.ApplicationRepository) *ApplicationService {
+	return &ApplicationService{applicationRepository: applicationRepository}
+}
+
+// CreateApplication can return  ConflictError, InternalServiceError, ValidationError
+func (applicationService *ApplicationService) CreateApplication(
+	application *models.CreateApplication) (*models.Application, error) {
+	if application == nil {
+		slog.Error("application_service.CreateApplication: application is nil")
+		return nil, internalErrors.NewValidationError(nil, "CreateApplication is nil")
+	}
+
+	err := application.Validate()
+	if err != nil {
+		var applicationID string
+		if application.ID != nil {
+			applicationID = application.ID.String()
+		} else {
+			applicationID = "[not set]"
+		}
+		slog.Info(
+			"company_service.CreateApplication: Application to create is invalid. ",
+			"ID", applicationID,
+			"error", err)
+		return nil, err
+	}
+
+	if application.CreatedDate == nil {
+		createdDate := time.Now()
+		application.CreatedDate = &createdDate
+	} else if application.CreatedDate.IsZero() {
+		createdDate := time.Now()
+		application.CreatedDate = &createdDate
+		slog.Info(
+			"application_service.createApplication: application.CreatedDate is zero. Setting to '" +
+				application.CreatedDate.String() + "'")
+	}
+
+	// can return ConflictError, InternalServiceError, ValidationError
+	insertedApplication, err := applicationService.applicationRepository.Create(application)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("application_service.createApplication: Inserted application.", "application.ID", insertedApplication.ID)
+	return insertedApplication, nil
+}
+
+// GetApplicationById can return  ConflictError, InternalServiceError, NewValidationError
+func (applicationService *ApplicationService) GetApplicationById(
+	applicationId *uuid.UUID) (*models.Application, error) {
+
+	if applicationId == nil {
+		applicationIdString := "application ID"
+		err := internalErrors.NewValidationError(&applicationIdString, "applicationId is required")
+		slog.Info("applicationService.GetApplicationById: Failed to get application", "error", err)
+		return nil, err
+	}
+
+	// can return InternalServiceError, NotFoundError, ValidationError
+	application, err := applicationService.applicationRepository.GetById(applicationId)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("ApplicationService.GetApplicationById: Retrieved company.", "company.ID", application.ID.String())
+
+	return application, nil
+}

--- a/internal/services/application_service_integration_test.go
+++ b/internal/services/application_service_integration_test.go
@@ -1,0 +1,257 @@
+package services_test
+
+import (
+	"errors"
+	configPackage "jobsearchtracker/internal/config"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/repositories"
+	"jobsearchtracker/internal/services"
+	"jobsearchtracker/internal/testutil/dependencyinjection"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupApplicationService(t *testing.T) (*services.ApplicationService, *repositories.CompanyRepository) {
+	config := &configPackage.Config{
+		DatabaseMigrationsPath:               "../../migrations",
+		IsDatabaseMigrationsPathAbsolutePath: false,
+	}
+
+	container := dependencyinjection.SetupApplicationServiceTestContainer(t, *config)
+
+	var applicationService *services.ApplicationService
+	err := container.Invoke(func(applicationSvc *services.ApplicationService) {
+		applicationService = applicationSvc
+	})
+	assert.NoError(t, err)
+
+	var companyRepository *repositories.CompanyRepository
+	err = container.Invoke(func(repository *repositories.CompanyRepository) {
+		companyRepository = repository
+	})
+	assert.NoError(t, err)
+
+	return applicationService, companyRepository
+}
+
+// -------- CreateApplication tests: --------
+
+func TestCreateApplication_ShouldWork(t *testing.T) {
+	applicationService, companyRepository := setupApplicationService(t)
+
+	companyID := createCompany(t, companyRepository)
+	recruiterID := createCompany(t, companyRepository)
+
+	id := uuid.New()
+	jobTitle := "Job Title"
+	jobAdURL := "Job Ad URL"
+	country := "Some Country"
+	area := "Some Area"
+	weekdaysInOffice := 9
+	estimatedCycleTime := 8
+	estimatedCommuteTime := 7
+	applicationDate := time.Now().AddDate(0, 0, 4)
+	createdDate := time.Now().AddDate(0, 0, 3)
+	updatedDate := time.Now().AddDate(0, 0, 2)
+
+	applicationToInsert := models.CreateApplication{
+		ID:                   &id,
+		CompanyID:            companyID,
+		RecruiterID:          recruiterID,
+		JobTitle:             &jobTitle,
+		JobAdURL:             &jobAdURL,
+		Country:              &country,
+		Area:                 &area,
+		RemoteStatusType:     models.RemoteStatusTypeHybrid,
+		WeekdaysInOffice:     &weekdaysInOffice,
+		EstimatedCycleTime:   &estimatedCycleTime,
+		EstimatedCommuteTime: &estimatedCommuteTime,
+		ApplicationDate:      &applicationDate,
+		CreatedDate:          &createdDate,
+		UpdatedDate:          &updatedDate,
+	}
+
+	insertedApplication, err := applicationService.CreateApplication(&applicationToInsert)
+	assert.NoError(t, err)
+	assert.NotNil(t, insertedApplication)
+
+	assert.Equal(t, id, insertedApplication.ID)
+	assert.Equal(t, companyID, insertedApplication.CompanyID)
+	assert.Equal(t, recruiterID, insertedApplication.RecruiterID)
+	assert.Equal(t, jobTitle, *insertedApplication.JobTitle)
+	assert.Equal(t, jobAdURL, *insertedApplication.JobAdURL)
+	assert.Equal(t, country, *insertedApplication.Country)
+	assert.Equal(t, area, *insertedApplication.Area)
+	assert.Equal(t, models.RemoteStatusTypeHybrid, insertedApplication.RemoteStatusType.String())
+	assert.Equal(t, weekdaysInOffice, *insertedApplication.WeekdaysInOffice)
+	assert.Equal(t, estimatedCycleTime, *insertedApplication.EstimatedCycleTime)
+	assert.Equal(t, estimatedCommuteTime, *insertedApplication.EstimatedCommuteTime)
+
+	applicationToInsertApplicationDate := applicationDate.Format(time.RFC3339)
+	insertedApplicationApplicationDate := insertedApplication.ApplicationDate.Format(time.RFC3339)
+	assert.Equal(t, applicationToInsertApplicationDate, insertedApplicationApplicationDate)
+
+	applicationToInsertCreatedDate := createdDate.Format(time.RFC3339)
+	insertedApplicationCreatedDate := insertedApplication.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, applicationToInsertCreatedDate, insertedApplicationCreatedDate)
+
+	applicationToInsertUpdatedDate := updatedDate.Format(time.RFC3339)
+	insertedApplicationUpdatedDate := insertedApplication.UpdatedDate.Format(time.RFC3339)
+	assert.Equal(t, applicationToInsertUpdatedDate, insertedApplicationUpdatedDate)
+}
+
+func TestCreateApplication_ShouldHandleEmptyFields(t *testing.T) {
+	applicationService, companyRepository := setupApplicationService(t)
+
+	companyID := createCompany(t, companyRepository)
+
+	jobAdURL := "Job Ad URL"
+	application := models.CreateApplication{
+		CompanyID:        companyID,
+		JobAdURL:         &jobAdURL,
+		RemoteStatusType: models.RemoteStatusTypeHybrid,
+	}
+
+	createdDateApproximation := time.Now().Format(time.RFC3339)
+	insertedApplication, err := applicationService.CreateApplication(&application)
+	assert.NoError(t, err)
+	assert.NotNil(t, insertedApplication)
+
+	assert.NotNil(t, insertedApplication.ID)
+	assert.Equal(t, companyID, insertedApplication.CompanyID)
+	assert.Nil(t, insertedApplication.RecruiterID)
+	assert.Nil(t, insertedApplication.JobTitle)
+	assert.Equal(t, jobAdURL, *insertedApplication.JobAdURL)
+	assert.Nil(t, insertedApplication.Country)
+	assert.Nil(t, insertedApplication.Area)
+	assert.Equal(t, models.RemoteStatusTypeHybrid, insertedApplication.RemoteStatusType.String())
+	assert.Nil(t, insertedApplication.WeekdaysInOffice)
+	assert.Nil(t, insertedApplication.EstimatedCycleTime)
+	assert.Nil(t, insertedApplication.EstimatedCommuteTime)
+	assert.Nil(t, insertedApplication.ApplicationDate)
+
+	insertedCompanyCreatedDate := insertedApplication.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, createdDateApproximation, insertedCompanyCreatedDate)
+	assert.Nil(t, insertedApplication.UpdatedDate)
+}
+
+func TestCreateApplication_ShouldReturnErrorIfCompanyIdIsNotInCompany(t *testing.T) {
+	applicationService, _ := setupApplicationService(t)
+
+	companyID := uuid.New()
+	jobAdURL := "Job Ad URL"
+	application := models.CreateApplication{
+		CompanyID:        &companyID,
+		JobAdURL:         &jobAdURL,
+		RemoteStatusType: models.RemoteStatusTypeHybrid,
+	}
+
+	response, err := applicationService.CreateApplication(&application)
+	assert.Nil(t, response)
+	assert.Error(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: Foreign key does not exist", err.Error())
+}
+
+func TestCreateApplication_ShouldReturnErrorIfRecruiterIdIsNotInCompany(t *testing.T) {
+	applicationService, _ := setupApplicationService(t)
+
+	recruiterID := uuid.New()
+	jobAdURL := "Job Ad URL"
+	application := models.CreateApplication{
+		RecruiterID:      &recruiterID,
+		JobAdURL:         &jobAdURL,
+		RemoteStatusType: models.RemoteStatusTypeHybrid,
+	}
+
+	response, err := applicationService.CreateApplication(&application)
+	assert.Nil(t, response)
+	assert.Error(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: Foreign key does not exist", err.Error())
+}
+
+// -------- GetApplicationById tests: --------
+
+func TestGetApplicationById_ShouldWork(t *testing.T) {
+	applicationService, companyRepository := setupApplicationService(t)
+
+	companyID := createCompany(t, companyRepository)
+	recruiterID := createCompany(t, companyRepository)
+
+	id := uuid.New()
+	jobTitle := "JobTitle"
+	jobAdURL := "JobAdURL"
+	country := "SomeCountry"
+	area := "SomeArea"
+	weekdaysInOffice := 9
+	estimatedCycleTime := 8
+	estimatedCommuteTime := 7
+	applicationDate := time.Now().AddDate(0, 0, 4)
+	createdDate := time.Now().AddDate(0, 0, 3)
+	updatedDate := time.Now().AddDate(0, 0, 2)
+
+	applicationToInsert := models.CreateApplication{
+		ID:                   &id,
+		CompanyID:            companyID,
+		RecruiterID:          recruiterID,
+		JobTitle:             &jobTitle,
+		JobAdURL:             &jobAdURL,
+		Country:              &country,
+		Area:                 &area,
+		RemoteStatusType:     models.RemoteStatusTypeHybrid,
+		WeekdaysInOffice:     &weekdaysInOffice,
+		EstimatedCycleTime:   &estimatedCycleTime,
+		EstimatedCommuteTime: &estimatedCommuteTime,
+		ApplicationDate:      &applicationDate,
+		CreatedDate:          &createdDate,
+		UpdatedDate:          &updatedDate,
+	}
+
+	insertedApplication, err := applicationService.CreateApplication(&applicationToInsert)
+	assert.NoError(t, err)
+	assert.NotNil(t, insertedApplication)
+
+	retrievedApplication, err := applicationService.GetApplicationById(&id)
+	assert.NoError(t, err)
+	assert.NotNil(t, retrievedApplication)
+
+}
+
+func TestGetApplicationById_ShouldReturnNotFoundErrorForAnIdThatDoesNotExist(t *testing.T) {
+	applicationService, _ := setupApplicationService(t)
+
+	id := uuid.New()
+	nilApplication, err := applicationService.GetApplicationById(&id)
+	assert.Nil(t, nilApplication)
+
+	assert.NotNil(t, err)
+	var notFoundError *internalErrors.NotFoundError
+	assert.True(t, errors.As(err, &notFoundError))
+	assert.Equal(t, "error: object not found: ID: '"+id.String()+"'", err.Error())
+}
+
+// -------- Test helpers: --------
+
+func createCompany(t *testing.T, companyRepository *repositories.CompanyRepository) *uuid.UUID {
+
+	id := uuid.New()
+	company := models.CreateCompany{
+		ID:          &id,
+		Name:        "Example Company Name",
+		CompanyType: models.CompanyTypeEmployer,
+	}
+
+	insertedCompany, err := companyRepository.Create(&company)
+	assert.NoError(t, err)
+
+	return &insertedCompany.ID
+}

--- a/internal/services/application_service_test.go
+++ b/internal/services/application_service_test.go
@@ -1,0 +1,160 @@
+package services
+
+import (
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/testutil"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- CreateApplication tests: --------
+
+func TestCreateApplication_ShouldReturnValidationErrorOnNilApplication(t *testing.T) {
+	applicationService := NewApplicationService(nil)
+
+	nilApplication, err := applicationService.CreateApplication(nil)
+	assert.Nil(t, nilApplication)
+	assert.NotNil(t, err)
+
+	var validationError *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationError))
+	assert.Equal(t, "validation error: CreateApplication is nil", err.Error())
+}
+
+func TestCreateApplication_ShouldReturnValidationErrorOnNilCompanyIDAndRecruiterID(t *testing.T) {
+	applicationService := NewApplicationService(nil)
+
+	jobTitle := "JobTitle"
+	application := models.CreateApplication{
+		CompanyID:        nil,
+		RecruiterID:      nil,
+		JobTitle:         &jobTitle,
+		RemoteStatusType: models.RemoteStatusTypeRemote,
+	}
+
+	nilApplication, err := applicationService.CreateApplication(&application)
+	assert.Nil(t, nilApplication)
+	assert.NotNil(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: CompanyID and RecruiterID cannot both be empty", err.Error())
+}
+
+func TestCreateApplication_ShouldReturnValidationErrorOnEmptyCompanyIDAndEmptyJobAdURL(t *testing.T) {
+	applicationService := NewApplicationService(nil)
+
+	tests := []struct {
+		testName     string
+		jobTitle     *string
+		jobAdURL     *string
+		errorMessage string
+	}{
+		{
+			"nil companyID and nil JobAdURL",
+			nil,
+			nil,
+			"validation error: JobTitle and JobAdURL cannot be both be nil",
+		},
+		{
+			"nil companyID and empty JobAdURL",
+			nil,
+			testutil.StringPtr(""),
+			"validation error: JobAdURL is empty",
+		},
+		{
+			"empty companyID and nil JobAdURL",
+			testutil.StringPtr(""),
+			nil,
+			"validation error: JobTitle is empty",
+		},
+		{
+			"empty companyID and empty JobAdURL",
+			testutil.StringPtr(""),
+			testutil.StringPtr(""),
+			"validation error: JobTitle is empty",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			companyID := uuid.New()
+
+			application := models.CreateApplication{
+				CompanyID:        &companyID,
+				JobTitle:         test.jobTitle,
+				JobAdURL:         test.jobAdURL,
+				RemoteStatusType: models.RemoteStatusTypeRemote,
+			}
+
+			nilApplication, err := applicationService.CreateApplication(&application)
+			assert.Nil(t, nilApplication)
+			assert.NotNil(t, err)
+
+			var validationErr *internalErrors.ValidationError
+			assert.True(t, errors.As(err, &validationErr))
+			assert.Equal(t, test.errorMessage, err.Error())
+		})
+	}
+}
+
+func TestCreateApplication_ShouldReturnValidationErrorOnInvalidApplicationType(t *testing.T) {
+	applicationService := NewApplicationService(nil)
+
+	recruiterID := uuid.New()
+	jobAdURL := "jobAdURL"
+	var remoteStatusType models.RemoteStatusType = "Not Valid"
+	application := models.CreateApplication{
+		RecruiterID:      &recruiterID,
+		JobAdURL:         &jobAdURL,
+		RemoteStatusType: remoteStatusType,
+	}
+
+	nilApplication, err := applicationService.CreateApplication(&application)
+	assert.Nil(t, nilApplication)
+	assert.NotNil(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: remoteStatusType is invalid", err.Error())
+}
+
+func TestCreateApplication_ShouldReturnValidationErrorOnUnsetUpdatedDate(t *testing.T) {
+	applicationService := NewApplicationService(nil)
+
+	companyID := uuid.New()
+	jobTitle := "JobTitle"
+	application := models.CreateApplication{
+		CompanyID:        &companyID,
+		JobTitle:         &jobTitle,
+		RemoteStatusType: models.RemoteStatusTypeRemote,
+		UpdatedDate:      &time.Time{},
+	}
+
+	nilApplication, err := applicationService.CreateApplication(&application)
+	assert.Nil(t, nilApplication)
+	assert.NotNil(t, err)
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(
+		t,
+		"validation error on field 'UpdatedDate': UpdatedDate is zero. It should either be 'nil' or a recent date. Given that this is an insert, it is recommended to use nil",
+		err.Error())
+}
+
+// -------- GetApplicationById tests: --------
+func TestGetApplicationById_ShouldReturnValidationErrorIfApplicationIdIsNil(t *testing.T) {
+	applicationService := NewApplicationService(nil)
+
+	nilApplication, err := applicationService.GetApplicationById(nil)
+	assert.Nil(t, nilApplication)
+	assert.NotNil(t, err)
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error on field 'application ID': applicationId is required", err.Error())
+}

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -1,8 +1,16 @@
 package testutil
 
-import "time"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
 
 func StringPtr(input string) *string {
+	return &input
+}
+
+func UUIDPtr(input uuid.UUID) *uuid.UUID {
 	return &input
 }
 

--- a/migrations/0003_add_application.down.sql
+++ b/migrations/0003_add_application.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE application;

--- a/migrations/0003_add_application.up.sql
+++ b/migrations/0003_add_application.up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS application
+(
+    id                      UUID        PRIMARY KEY,
+    company_id              UUID        NULLABLE,
+    recruiter_id            UUID        NULLABLE,
+    job_title               TEXT        NULLABLE,
+    job_ad_url              TEXT        NULLABLE,
+    country                 TEXT        NULLABLE,
+    area                    TEXT        NULLABLE,
+    remote_status_type      TEXT        NOT NULL    CHECK (remote_status_type IN ('hybrid', 'office', 'remote', 'unknown')),
+    weekdays_in_office      INT         NULLABLE,
+    estimated_cycle_time    INT         NULLABLE,
+    estimated_commute_time  INT         NULLABLE,
+    application_date        DATETIME    NULLABLE,
+    created_date            DATETIME    NOT NULL    DEFAULT CURRENT_TIMESTAMP,
+    updated_date            DATETIME    NULLABLE,
+    CONSTRAINT fk_application_company FOREIGN KEY(company_id) REFERENCES company(id),
+    CONSTRAINT fk_application_recruiter FOREIGN KEY(recruiter_id) REFERENCES company(id),
+    CONSTRAINT company_reference_not_null CHECK (company_id IS NOT NULL OR recruiter_id IS NOT NULL),
+    CONSTRAINT job_title_job_url_not_null CHECK (job_title IS NOT NULL OR job_ad_url IS NOT NULL)
+);


### PR DESCRIPTION
- Added SQL to create `application` table.
- Updated database connection string to enforce foreign keys.
- Added application models.

- Added `UUIDPtr()` to test helpers.
- Added `ApplicationRepository` along with `Create()` and `GetByID()`.
- Added `ApplicationService` along with `CreateApplication()` and `GetApplicationByID()`.
- Added `ApplicationHandlers` along with `CreateApplication()` and `GetApplicationById()`.
- Added endpoints to `server.go`.