### PR TITLE
Add company-person

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -31,6 +31,10 @@ func NewServer(database *sql.DB, logger *slog.Logger) *Server {
 	applicationService := services.NewApplicationService(applicationRepository)
 	applicationHandler := apiV1.NewApplicationHandler(applicationService)
 
+	companyPersonRepository := repositories.NewCompanyPersonRepository(database)
+	companyPersonService := services.NewCompanyPersonService(companyPersonRepository)
+	companyPersonHandler := apiV1.NewCompanyPersonHandler(companyPersonService)
+
 	router := mux.NewRouter()
 
 	router.HandleFunc("/api/v1/company/new", companyHandler.CreateCompany).Methods(http.MethodPost)
@@ -52,7 +56,11 @@ func NewServer(database *sql.DB, logger *slog.Logger) *Server {
 	router.HandleFunc("/api/v1/application/get/title/{title}", applicationHandler.GetApplicationsByJobTitle).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/application/get/all", applicationHandler.GetAllApplications).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/application/update", applicationHandler.UpdateApplication).Methods(http.MethodPost)
-	router.HandleFunc("/api/v1/application/delete/{id}", applicationHandler.DeleteApplication).Methods(http.MethodDelete)
+
+	router.HandleFunc("/api/v1/company-person/associate", companyPersonHandler.AssociateCompanyPerson).Methods(http.MethodPost)
+	router.HandleFunc("/api/v1/company-person/get/", companyPersonHandler.GetCompanyPersonsByID).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/company-person/get/all", companyPersonHandler.GetAllCompanyPersons).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/company-person/delete", companyPersonHandler.DeleteCompanyPerson).Methods(http.MethodDelete)
 
 	slog.Info("Server created. Returning Server.")
 	return &Server{router: router, logger: logger}

--- a/internal/api/v1/handlers/company_person_handlers.go
+++ b/internal/api/v1/handlers/company_person_handlers.go
@@ -1,0 +1,274 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"jobsearchtracker/internal/api/v1/requests"
+	"jobsearchtracker/internal/api/v1/responses"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/services"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+type CompanyPersonHandler struct {
+	companyPersonService *services.CompanyPersonService
+}
+
+func NewCompanyPersonHandler(companyPersonService *services.CompanyPersonService) *CompanyPersonHandler {
+	return &CompanyPersonHandler{companyPersonService: companyPersonService}
+}
+
+func (handler *CompanyPersonHandler) AssociateCompanyPerson(writer http.ResponseWriter, request *http.Request) {
+	var createCompanyPersonRequest requests.AssociateCompanyPersonRequest
+	if err := json.NewDecoder(request.Body).Decode(&createCompanyPersonRequest); err != nil {
+		slog.Info("v1.CompanyPersonHandler.AssociateCompanyPerson: invalid request body", "error", err)
+		http.Error(writer, "invalid request body: Unable to parse JSON", http.StatusBadRequest)
+		return
+	}
+
+	// can return ValidationError
+	createCompanyPersonModel, err := createCompanyPersonRequest.ToModel()
+	if err != nil {
+		slog.Info(
+			"v1.CompanyPersonHandler.AssociateCompanyPerson: Unable to convert CreateCompanyPersonRequest to model",
+			"error", err)
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if createCompanyPersonModel == nil {
+		slog.Info("v1.CompanyPersonHandler.AssociateCompanyPerson: CreateCompanyPerson model is nil")
+		http.Error(writer,
+			"Unable to convert request to internal model: Internal model is nil",
+			http.StatusInternalServerError)
+		return
+	}
+
+	// can return ConflictError, InternalServiceError, ValidationError
+	companyPersonModel, err := handler.companyPersonService.AssociateCompanyPerson(createCompanyPersonModel)
+
+	if err != nil {
+		var conflictErr *internalErrors.ConflictError
+		var internalServiceErr *internalErrors.InternalServiceError
+		var validationErr *internalErrors.ValidationError
+
+		var errorMessage string
+		var status int
+
+		if errors.As(err, &conflictErr) {
+			errorMessage = "Conflict error on insert: ID already exists"
+			status = http.StatusConflict
+			slog.Info("v1.CompanyPersonHandler.AssociateCompanyPerson: ConflictError creating record", "error", err)
+		} else if errors.As(err, &internalServiceErr) {
+			errorMessage = "Internal service error while associating person to company"
+			status = http.StatusInternalServerError
+			slog.Error("v1.CompanyPersonHandler.AssociateCompanyPerson: "+errorMessage, "error", err)
+		} else if errors.As(err, &validationErr) {
+			errorMessage = err.Error()
+			status = http.StatusBadRequest
+			slog.Info(
+				"v1.CompanyPersonHandler.AssociateCompanyPerson: ValidationError while associating person to company",
+				"error", err)
+		} else {
+			errorMessage = "Unknown internal error while associating person to company"
+			status = http.StatusInternalServerError
+			slog.Error(
+				"v1.CompanyPersonHandler.AssociateCompanyPerson: Error while associating person to company",
+				"error", err)
+		}
+		http.Error(writer, errorMessage, status)
+
+		return
+	}
+
+	// can return InternalServiceError
+	response := responses.NewCompanyPersonResponse(companyPersonModel)
+
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(http.StatusCreated)
+	err = json.NewEncoder(writer).Encode(response)
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		slog.Error("v1.PersonHandler.AssociateCompanyPerson: Unable to write response", "error", err)
+		http.Error(writer, "Person created but unable to create response", http.StatusInternalServerError)
+
+		return
+	}
+}
+
+func (handler *CompanyPersonHandler) GetCompanyPersonsByID(writer http.ResponseWriter, request *http.Request) {
+	query := request.URL.Query()
+	companyIDString := query.Get("company-id")
+	personIDString := query.Get("person-id")
+
+	if companyIDString == "" && personIDString == "" {
+		errorMessage := "CompanyID and/or PersonID are required"
+		slog.Info("v1.CompanyPersonHandler.GetCompanyPersonsByID: " + errorMessage)
+
+		status := http.StatusBadRequest
+		writer.WriteHeader(status)
+		http.Error(writer, errorMessage, status)
+		return
+	}
+
+	var companyID, personID *uuid.UUID = nil, nil
+
+	if companyIDString != "" {
+		companyIDValue, err := uuid.Parse(companyIDString)
+		if err != nil || companyIDValue == uuid.Nil {
+			errorMessage := "Unable to parse CompanyID"
+			slog.Info("v1.CompanyPersonHandler.GetCompanyPersonsByID: " + errorMessage)
+
+			status := http.StatusBadRequest
+			writer.WriteHeader(status)
+			http.Error(writer, errorMessage, status)
+			return
+		}
+
+		companyID = &companyIDValue
+	}
+
+	if personIDString != "" {
+		personIDValue, err := uuid.Parse(personIDString)
+		if err != nil || personIDValue == uuid.Nil {
+			errorMessage := "Unable to parse PersonID"
+			slog.Info("v1.CompanyPersonHandler.GetCompanyPersonsByID: " + errorMessage)
+
+			status := http.StatusBadRequest
+			writer.WriteHeader(status)
+			http.Error(writer, errorMessage, status)
+			return
+		}
+		personID = &personIDValue
+	}
+
+	companyPersons, err := handler.companyPersonService.GetByID(companyID, personID)
+	if err != nil {
+		errorMessage := "Internal service error while getting companyPersons by ID"
+		slog.Error("v1.CompanyPersonHandler.GetCompanyPersonsByID: "+errorMessage, "error", err)
+
+		status := http.StatusInternalServerError
+		writer.WriteHeader(status)
+		http.Error(writer, errorMessage, status)
+		return
+	}
+
+	response := responses.NewCompanyPersonsResponse(companyPersons)
+
+	writer.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(writer).Encode(response)
+	if err != nil {
+		slog.Error("v1.CompanyPersonHandler.GetCompanyPersonsByID: Unable to write response", "error", err)
+
+		status := http.StatusInternalServerError
+		writer.WriteHeader(status)
+		http.Error(writer, "Companies retrieved but unable to create response", status)
+
+		return
+	}
+
+	slog.Info("v1.CompanyPersonHandler.GetCompanyPersonsByID: retrieved all companies successfully")
+
+	return
+}
+
+func (handler *CompanyPersonHandler) GetAllCompanyPersons(writer http.ResponseWriter, request *http.Request) {
+	companyPersons, err := handler.companyPersonService.GetAll()
+	if err != nil {
+		errorMessage := "Internal service error while getting all companyPersons"
+		slog.Error("v1.CompanyHandler.GetAllCompanyPersons: "+errorMessage, "error", err)
+
+		status := http.StatusInternalServerError
+		writer.WriteHeader(status)
+		http.Error(writer, errorMessage, status)
+		return
+	}
+
+	companyPersonsResponse := responses.NewCompanyPersonsResponse(companyPersons)
+
+	writer.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(writer).Encode(companyPersonsResponse)
+	if err != nil {
+		slog.Error("v1.CompanyPersonHandler.GetAllCompanyPersons: Unable to write response", "error", err)
+
+		status := http.StatusInternalServerError
+		writer.WriteHeader(status)
+		http.Error(writer, "Companies retrieved but unable to create response", status)
+
+		return
+	}
+
+	slog.Info("v1.CompanyPersonHandler.GetAllCompanyPersons: retrieved all CompanyPersons successfully")
+
+	return
+}
+
+// DeleteCompanyPerson can return InternalServiceError, ValidationError
+func (handler *CompanyPersonHandler) DeleteCompanyPerson(writer http.ResponseWriter, request *http.Request) {
+	var deleteRequest requests.DeleteCompanyPersonRequest
+	if err := json.NewDecoder(request.Body).Decode(&deleteRequest); err != nil {
+		slog.Info("v1.CompanyPersonHandler.DeleteCompanyPerson: invalid request body", "error", err)
+		http.Error(writer, "invalid request body: Unable to parse JSON", http.StatusBadRequest)
+		return
+	}
+
+	// can return ValidationError
+	deleteModel, err := deleteRequest.ToModel()
+	if err != nil {
+		slog.Info(
+			"v1.CompanyPersonHandler.DeleteCompanyPerson: Unable to convert DeleteCompanyPersonRequest to model",
+			"error", err)
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if deleteModel == nil {
+		slog.Info("v1.CompanyPersonHandler.AssociateCompanyPerson: DeleteCompanyPerson is nil")
+		http.Error(writer,
+			"Unable to convert request to internal model: Internal model is nil",
+			http.StatusInternalServerError)
+		return
+	}
+
+	// can return InternalServiceError, NotFoundError, ValidationError
+	err = handler.companyPersonService.Delete(deleteModel)
+	if err != nil {
+		var internalServiceErr *internalErrors.InternalServiceError
+		var notFoundErr *internalErrors.NotFoundError
+		var validationErr *internalErrors.ValidationError
+
+		var errorMessage string
+		var status int
+
+		if errors.As(err, &internalServiceErr) {
+			errorMessage = "Internal service error while deleting CompanyPerson"
+			status = http.StatusInternalServerError
+			slog.Error("v1.CompanyPersonHandler.DeleteCompanyPerson: "+errorMessage, "error", err)
+		} else if errors.As(err, &notFoundErr) {
+			errorMessage = err.Error()
+			status = http.StatusNotFound
+			slog.Info(
+				"v1.CompanyPersonHandler.DeleteCompanyPerson: NotFoundErr while deleting CompanyPerson", "error",
+				err)
+		} else if errors.As(err, &validationErr) {
+			errorMessage = err.Error()
+			status = http.StatusBadRequest
+			slog.Info(
+				"v1.CompanyPersonHandler.DeleteCompanyPerson: ValidationError while deleting CompanyPerson", "error",
+				err)
+		} else {
+			errorMessage = "Unknown internal error while creating company"
+			status = http.StatusInternalServerError
+			slog.Error("v1.CompanyPersonHandler.DeleteCompanyPerson: Error while deleting CompanyPerson", "error", err)
+		}
+		http.Error(writer, errorMessage, status)
+
+		return
+	}
+
+	writer.WriteHeader(http.StatusOK)
+	return
+}

--- a/internal/api/v1/handlers/company_person_handlers_integration_test.go
+++ b/internal/api/v1/handlers/company_person_handlers_integration_test.go
@@ -1,0 +1,409 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"jobsearchtracker/internal/api/v1/handlers"
+	"jobsearchtracker/internal/api/v1/requests"
+	"jobsearchtracker/internal/api/v1/responses"
+	configPackage "jobsearchtracker/internal/config"
+	"jobsearchtracker/internal/repositories"
+	"jobsearchtracker/internal/testutil/dependencyinjection"
+	"jobsearchtracker/internal/testutil/repositoryhelpers"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupCompanyPersonHandler(t *testing.T) (
+	*handlers.CompanyPersonHandler, *repositories.CompanyRepository, *repositories.PersonRepository) {
+
+	config := configPackage.Config{
+		DatabaseMigrationsPath:               "../../../../migrations",
+		IsDatabaseMigrationsPathAbsolutePath: false,
+	}
+
+	container := dependencyinjection.SetupCompanyPersonHandlerTestContainer(t, config)
+
+	var companyPersonHandler *handlers.CompanyPersonHandler
+	err := container.Invoke(func(handler *handlers.CompanyPersonHandler) {
+		companyPersonHandler = handler
+	})
+	assert.NoError(t, err)
+
+	var companyRepository *repositories.CompanyRepository
+	err = container.Invoke(func(repository *repositories.CompanyRepository) {
+		companyRepository = repository
+	})
+	assert.NoError(t, err)
+
+	var personRepository *repositories.PersonRepository
+	err = container.Invoke(func(repository *repositories.PersonRepository) {
+		personRepository = repository
+	})
+	assert.NoError(t, err)
+
+	return companyPersonHandler, companyRepository, personRepository
+}
+
+// -------- AssociateCompanyPerson tests: --------
+
+func TestAssociateCompanyPerson_ShouldWork(t *testing.T) {
+	companyPersonHandler, companyRepository, personRepository := setupCompanyPersonHandler(t)
+
+	company := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	person := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson := requests.AssociateCompanyPersonRequest{
+		CompanyID: company.ID,
+		PersonID:  person.ID,
+	}
+
+	requestBytes, err := json.Marshal(companyPerson)
+	assert.NoError(t, err)
+
+	request, err := http.NewRequest("POST", "/api/v1/company-person/associate", bytes.NewReader(requestBytes))
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+	companyPersonHandler.AssociateCompanyPerson(responseRecorder, request)
+	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString)
+
+	var companyPersonResponse responses.CompanyPersonResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&companyPersonResponse)
+	assert.NoError(t, err)
+
+	assert.Equal(t, company.ID, companyPersonResponse.CompanyID)
+	assert.Equal(t, person.ID, companyPersonResponse.PersonID)
+	assert.NotNil(t, companyPersonResponse.CreatedDate)
+}
+
+// -------- GetCompanyPersonsByID tests: --------
+
+func TestGetCompanyPersonsByID_ShouldWork(t *testing.T) {
+	companyPersonHandler, companyRepository, personRepository := setupCompanyPersonHandler(t)
+
+	_, company2ID, person1ID, _ :=
+		setupTestData(t, companyPersonHandler, companyRepository, personRepository, false)
+
+	queryParams := "company-id=" + company2ID.String() + "&person-id=" + person1ID.String()
+
+	getRequest, err := http.NewRequest(http.MethodGet, "/api/v1/company/company-person/get/?"+queryParams, nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	companyPersonHandler.GetCompanyPersonsByID(responseRecorder, getRequest)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString)
+
+	var response []responses.CompanyPersonResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&response)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, response)
+	assert.Equal(t, 1, len(response))
+
+	assert.Equal(t, company2ID, response[0].CompanyID)
+	assert.Equal(t, person1ID, response[0].PersonID)
+	assert.NotNil(t, response[0].CreatedDate)
+}
+
+func TestGetCompanyPersonsByID_ShouldReturnAllMatchingCompanies(t *testing.T) {
+	companyPersonHandler, companyRepository, personRepository := setupCompanyPersonHandler(t)
+
+	_, company2ID, person1ID, person2ID :=
+		setupTestData(t, companyPersonHandler, companyRepository, personRepository, true)
+
+	queryParams := "company-id=" + company2ID.String()
+
+	getRequest, err := http.NewRequest(http.MethodGet, "/api/v1/company/company-person/get/?"+queryParams, nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	companyPersonHandler.GetCompanyPersonsByID(responseRecorder, getRequest)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString)
+
+	var response []responses.CompanyPersonResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&response)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, response)
+	assert.Equal(t, 2, len(response))
+
+	assert.Equal(t, company2ID, response[0].CompanyID)
+	assert.Equal(t, person1ID, response[0].PersonID)
+	assert.NotNil(t, response[0].CreatedDate)
+
+	assert.Equal(t, company2ID, response[1].CompanyID)
+	assert.Equal(t, person2ID, response[1].PersonID)
+	assert.NotNil(t, response[1].CreatedDate)
+}
+
+func TestGetCompanyPersonsByID_ShouldReturnAllMatchingPersons(t *testing.T) {
+	companyPersonHandler, companyRepository, personRepository := setupCompanyPersonHandler(t)
+
+	company1ID, company2ID, person1ID, _ :=
+		setupTestData(t, companyPersonHandler, companyRepository, personRepository, true)
+
+	queryParams := "person-id=" + person1ID.String()
+
+	getRequest, err := http.NewRequest(http.MethodGet, "/api/v1/company/company-person/get/?"+queryParams, nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	companyPersonHandler.GetCompanyPersonsByID(responseRecorder, getRequest)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString)
+
+	var response []responses.CompanyPersonResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&response)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, response)
+	assert.Equal(t, 2, len(response))
+
+	assert.Equal(t, company2ID, response[0].CompanyID)
+	assert.Equal(t, person1ID, response[0].PersonID)
+	assert.NotNil(t, response[0].CreatedDate)
+
+	assert.Equal(t, company1ID, response[1].CompanyID)
+	assert.Equal(t, person1ID, response[1].PersonID)
+	assert.NotNil(t, response[1].CreatedDate)
+}
+
+func TestGetCompanyPersonsByID_ShouldReturnEmptyResponseIfNoMatchingCompanyPersons(t *testing.T) {
+	companyPersonHandler, companyRepository, personRepository := setupCompanyPersonHandler(t)
+
+	setupTestData(t, companyPersonHandler, companyRepository, personRepository, false)
+
+	queryParams := "company-id=" + uuid.New().String() + "&person-id=" + uuid.New().String()
+
+	getRequest, err := http.NewRequest(http.MethodGet, "/api/v1/company/company-person/get/?"+queryParams, nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	companyPersonHandler.GetCompanyPersonsByID(responseRecorder, getRequest)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString)
+
+	var response []responses.CompanyPersonResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&response)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, response)
+	assert.Equal(t, 0, len(response))
+}
+
+// -------- GetAllCompanyPersons tests: --------
+
+func TestGetAllCompanyPersons_ShouldReturnAllCompanyPersons(t *testing.T) {
+	companyPersonHandler, companyRepository, personRepository := setupCompanyPersonHandler(t)
+
+	company1ID, company2ID, person1ID, person2ID :=
+		setupTestData(t, companyPersonHandler, companyRepository, personRepository, true)
+
+	getRequest, err := http.NewRequest(http.MethodGet, "/api/v1/company/company-person/get/all", nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	companyPersonHandler.GetAllCompanyPersons(responseRecorder, getRequest)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString)
+
+	var response []responses.CompanyPersonResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&response)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, response)
+	assert.Equal(t, 3, len(response))
+
+	assert.Equal(t, company2ID, response[0].CompanyID)
+	assert.Equal(t, person1ID, response[0].PersonID)
+	assert.NotNil(t, response[0].CreatedDate)
+
+	assert.Equal(t, company2ID, response[1].CompanyID)
+	assert.Equal(t, person2ID, response[1].PersonID)
+	assert.NotNil(t, response[1].CreatedDate)
+
+	assert.Equal(t, company1ID, response[2].CompanyID)
+	assert.Equal(t, person1ID, response[2].PersonID)
+	assert.NotNil(t, response[2].CreatedDate)
+}
+
+func TestGetAllCompanyPersons_ShouldReturnNothingIfNothingInDatabase(t *testing.T) {
+	companyPersonHandler, _, _ := setupCompanyPersonHandler(t)
+
+	getRequest, err := http.NewRequest(http.MethodGet, "/api/v1/company/company-person/get/all", nil)
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+
+	companyPersonHandler.GetAllCompanyPersons(responseRecorder, getRequest)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.NotEmpty(t, responseBodyString)
+
+	var response []responses.CompanyPersonResponse
+	err = json.NewDecoder(responseRecorder.Body).Decode(&response)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, response)
+	assert.Equal(t, 0, len(response))
+}
+
+// -------- DeleteCompanyPerson tests: --------
+
+func TestDeleteCompanyPerson_ShouldDeleteCompanyPerson(t *testing.T) {
+	companyPersonHandler, companyRepository, personRepository := setupCompanyPersonHandler(t)
+
+	company := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	person := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson := requests.AssociateCompanyPersonRequest{
+		CompanyID: company.ID,
+		PersonID:  person.ID,
+	}
+
+	requestBytes, err := json.Marshal(companyPerson)
+	assert.NoError(t, err)
+
+	request, err := http.NewRequest("POST", "/api/v1/company-person/associate", bytes.NewReader(requestBytes))
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+	companyPersonHandler.AssociateCompanyPerson(responseRecorder, request)
+	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+
+	deleteRequest := requests.DeleteCompanyPersonRequest{
+		CompanyID: company.ID,
+		PersonID:  person.ID,
+	}
+
+	requestBytes, err = json.Marshal(deleteRequest)
+	assert.NoError(t, err)
+
+	request, err = http.NewRequest("POST", "/api/v1/company-person/delete", bytes.NewReader(requestBytes))
+	assert.NoError(t, err)
+
+	responseRecorder = httptest.NewRecorder()
+	companyPersonHandler.DeleteCompanyPerson(responseRecorder, request)
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.Equal(t, "", responseBodyString)
+}
+
+func TestDeleteCompanyPerson_ShouldReturnErrorIfNoMatchingCompanyPersonToDelete(t *testing.T) {
+	companyPersonHandler, _, _ := setupCompanyPersonHandler(t)
+
+	companyID, personID := uuid.New(), uuid.New()
+	deleteRequest := requests.DeleteCompanyPersonRequest{
+		CompanyID: companyID,
+		PersonID:  personID,
+	}
+
+	requestBytes, err := json.Marshal(deleteRequest)
+	assert.NoError(t, err)
+
+	request, err := http.NewRequest("POST", "/api/v1/company-person/delete", bytes.NewReader(requestBytes))
+	assert.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+	companyPersonHandler.DeleteCompanyPerson(responseRecorder, request)
+	assert.Equal(t, http.StatusNotFound, responseRecorder.Code)
+
+	responseBodyString := responseRecorder.Body.String()
+	assert.Equal(
+		t,
+		"error: object not found: CompanyPerson does not exist. companyID: "+
+			companyID.String()+", personID: "+personID.String()+"\n",
+		responseBodyString)
+}
+
+// -------- test helpers: --------
+
+func setupTestData(
+	t *testing.T,
+	companyPersonHandler *handlers.CompanyPersonHandler,
+	companyRepository *repositories.CompanyRepository,
+	personRepository *repositories.PersonRepository,
+	sleep bool) (
+	uuid.UUID, uuid.UUID, uuid.UUID, uuid.UUID) {
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	company2 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	person2 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := requests.AssociateCompanyPersonRequest{
+		CompanyID: company1.ID,
+		PersonID:  person1.ID,
+	}
+	requestBytes, err := json.Marshal(companyPerson1)
+	assert.NoError(t, err)
+	request, err := http.NewRequest("POST", "/api/v1/company-person/associate", bytes.NewReader(requestBytes))
+	assert.NoError(t, err)
+	responseRecorder := httptest.NewRecorder()
+	companyPersonHandler.AssociateCompanyPerson(responseRecorder, request)
+	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+
+	if sleep {
+		// a sleep is needed in order to ensure the order of the records.
+		//There needs to be a minimum of 1 second between inserts.
+		time.Sleep(1000 * time.Millisecond)
+	}
+
+	companyPerson2 := requests.AssociateCompanyPersonRequest{
+		CompanyID: company2.ID,
+		PersonID:  person2.ID,
+	}
+	requestBytes, err = json.Marshal(companyPerson2)
+	assert.NoError(t, err)
+	request, err = http.NewRequest("POST", "/api/v1/company-person/associate", bytes.NewReader(requestBytes))
+	assert.NoError(t, err)
+	responseRecorder = httptest.NewRecorder()
+	companyPersonHandler.AssociateCompanyPerson(responseRecorder, request)
+	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+
+	if sleep {
+		time.Sleep(1000 * time.Millisecond)
+	}
+
+	companyPerson3 := requests.AssociateCompanyPersonRequest{
+		CompanyID: company2.ID,
+		PersonID:  person1.ID,
+	}
+	requestBytes, err = json.Marshal(companyPerson3)
+	assert.NoError(t, err)
+	request, err = http.NewRequest("POST", "/api/v1/company-person/associate", bytes.NewReader(requestBytes))
+	assert.NoError(t, err)
+	responseRecorder = httptest.NewRecorder()
+	companyPersonHandler.AssociateCompanyPerson(responseRecorder, request)
+	assert.Equal(t, http.StatusCreated, responseRecorder.Code)
+
+	return company1.ID, company2.ID, person1.ID, person2.ID
+}

--- a/internal/api/v1/handlers/company_person_handlers_test.go
+++ b/internal/api/v1/handlers/company_person_handlers_test.go
@@ -1,0 +1,214 @@
+package handlers
+
+import (
+	"bytes"
+	"jobsearchtracker/internal/testutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- AssociateCompanyPerson tests: --------
+
+func TestAssociateCompanyPerson_ShouldRespondWithBadRequestStatus(t *testing.T) {
+	tests := []struct {
+		testName             string
+		inputRequest         *string
+		expectedResponseCode int
+		expectedErrorMessage string
+	}{
+		{
+			testName:             "body is nil",
+			inputRequest:         nil,
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n"},
+		{
+			testName:             "body is empty",
+			inputRequest:         testutil.ToPtr(""),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n"},
+		{
+			testName:             "company_id is missing",
+			inputRequest:         testutil.ToPtr(`{"person_id": "8b802e50-f164-4d92-9f27-8cd91167f1e8"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error: CompanyID is invalid\n"},
+		{
+			testName:             "company_id is empty",
+			inputRequest:         testutil.ToPtr(`{"company_id": "", "person_id": "8b802e50-f164-4d92-9f27-8cd91167f1e8"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n"},
+		{
+			testName:             "company_id is invalid",
+			inputRequest:         testutil.ToPtr(`{"company_id": "not valid", "person_id": "8b802e50-f164-4d92-9f27-8cd91167f1e8"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n"},
+		{
+			testName:             "person_id is missing",
+			inputRequest:         testutil.ToPtr(`{"company_id": "8b802e50-f164-4d92-9f27-8cd91167f1e8"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "validation error: PersonID is invalid\n"},
+		{
+			testName:             "person_id is empty",
+			inputRequest:         testutil.ToPtr(`{"company_id": "06f92026-5b76-431a-909d-005ae920f4e4", "person_id": ""}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n"},
+		{
+			testName:             "person_id is invalid",
+			inputRequest:         testutil.ToPtr(`{"company_id": "06f92026-5b76-431a-909d-005ae920f4e4", "person_id": "not valid"}`),
+			expectedResponseCode: http.StatusBadRequest,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n"},
+	}
+	handler := NewCompanyPersonHandler(nil)
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			var requestBody []byte
+			if test.inputRequest != nil {
+				requestBody = []byte(*test.inputRequest)
+			} else {
+				requestBody = nil
+			}
+
+			request, err := http.NewRequest("POST", "/api/v1/company-person/associate", bytes.NewReader(requestBody))
+			assert.NoError(t, err)
+
+			responseRecorder := httptest.NewRecorder()
+			handler.AssociateCompanyPerson(responseRecorder, request)
+			assert.Equal(t, test.expectedResponseCode, responseRecorder.Code)
+
+			responseBodyString := responseRecorder.Body.String()
+			assert.Equal(t, test.expectedErrorMessage, responseBodyString)
+		})
+	}
+
+}
+
+// -------- GetCompanyPersonsByID tests: --------
+
+func TestGetCompanyPersonsByID_ShouldRespondWithBadRequestStatus(t *testing.T) {
+	tests := []struct {
+		testName             string
+		queryParams          string
+		expectedErrorMessage string
+	}{
+		{
+			testName:             "nil companyID and nil personID",
+			queryParams:          "",
+			expectedErrorMessage: "CompanyID and/or PersonID are required\n",
+		},
+		{
+			testName:             "empty companyID and empty personID",
+			queryParams:          `?company_id=&person_id=`,
+			expectedErrorMessage: "CompanyID and/or PersonID are required\n",
+		},
+		{
+			testName:             "empty companyID and nil personID",
+			queryParams:          `?company_id=`,
+			expectedErrorMessage: "CompanyID and/or PersonID are required\n",
+		},
+		{
+			testName:             "nil companyID and empty personID",
+			queryParams:          `?person_id=`,
+			expectedErrorMessage: "CompanyID and/or PersonID are required\n",
+		},
+		{
+			testName:             "invalid companyID",
+			queryParams:          `?company_id=not-valid&person_id=8b802e50-f164-4d92-9f27-8cd91167f1e8`,
+			expectedErrorMessage: "CompanyID and/or PersonID are required\n",
+		},
+		{
+			testName:             "invalid personID",
+			queryParams:          `?company_id=06f92026-5b76-431a-909d-005ae920f4e4&person_id=not-valid`,
+			expectedErrorMessage: "CompanyID and/or PersonID are required\n",
+		},
+	}
+
+	handler := NewCompanyPersonHandler(nil)
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+
+			request, err := http.NewRequest(http.MethodGet, "/api/v1/company-person/get"+test.queryParams, nil)
+			assert.NoError(t, err)
+
+			responseRecorder := httptest.NewRecorder()
+			handler.GetCompanyPersonsByID(responseRecorder, request)
+			assert.Equal(t, http.StatusBadRequest, responseRecorder.Code)
+
+			responseBodyString := responseRecorder.Body.String()
+			assert.Equal(t, test.expectedErrorMessage, responseBodyString)
+		})
+	}
+}
+
+// --------DeleteCompanyPerson tests: --------
+
+func TestDeleteCompanyPerson_ShouldRespondWithBadRequestStatus(t *testing.T) {
+	tests := []struct {
+		testName             string
+		body                 string
+		expectedResponseCode int
+		expectedErrorMessage string
+	}{
+		{
+			testName:             "empty body",
+			body:                 "",
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n",
+		},
+		{
+			testName:             "empty companyID and empty personID",
+			body:                 `{"company_id":"", "person_id":""}`,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n",
+		},
+		{
+			testName:             "empty companyID and nil personID",
+			body:                 `"{company_id":""}`,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n",
+		},
+		{
+			testName:             "nil companyID and empty personID",
+			body:                 `{"person_id":""}`,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n",
+		},
+		{
+			testName:             "invalid companyID",
+			body:                 `"company_id":"not valid","person_id":"8b802e50-f164-4d92-9f27-8cd91167f1e8"}"`,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n",
+		},
+		{
+			testName:             "nil companyID",
+			body:                 `{"person_id":"8b802e50-f164-4d92-9f27-8cd91167f1e8"}`,
+			expectedErrorMessage: "validation error: CompanyID is invalid\n",
+		},
+		{
+			testName:             "invalid personID",
+			body:                 `{"company_id":"06f92026-5b76-431a-909d-005ae920f4e4","person_id":"not valid"}`,
+			expectedErrorMessage: "invalid request body: Unable to parse JSON\n",
+		},
+		{
+			testName:             "nil personID",
+			body:                 `{"company_id":"06f92026-5b76-431a-909d-005ae920f4e4"}"`,
+			expectedErrorMessage: "validation error: PersonID is invalid\n",
+		},
+	}
+	handler := NewCompanyPersonHandler(nil)
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+
+			requestBody := []byte(test.body)
+
+			request, err := http.NewRequest(http.MethodGet, "/api/v1/company-person/get", bytes.NewReader(requestBody))
+			assert.NoError(t, err)
+
+			responseRecorder := httptest.NewRecorder()
+			handler.DeleteCompanyPerson(responseRecorder, request)
+			assert.Equal(t, http.StatusBadRequest, responseRecorder.Code)
+
+			responseBodyString := responseRecorder.Body.String()
+			assert.Equal(t, test.expectedErrorMessage, responseBodyString)
+		})
+	}
+
+}

--- a/internal/api/v1/requests/company_person_requests.go
+++ b/internal/api/v1/requests/company_person_requests.go
@@ -1,0 +1,99 @@
+package requests
+
+import (
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"log/slog"
+
+	"github.com/google/uuid"
+)
+
+type AssociateCompanyPersonRequest struct {
+	CompanyID uuid.UUID `json:"company_id"`
+	PersonID  uuid.UUID `json:"person_id"`
+}
+
+// validate can return ValidationError
+func (request *AssociateCompanyPersonRequest) validate() error {
+	if request == nil {
+		message := "request is nil"
+		slog.Info("CreateCompanyPersonRequest.validate failed: " + message)
+		return internalErrors.NewValidationError(nil, message)
+	}
+
+	if request.CompanyID == uuid.Nil {
+		message := "CompanyID is invalid"
+		slog.Info("CreateCompanyPersonRequest.validate failed: " + message)
+		return internalErrors.NewValidationError(nil, message)
+	}
+
+	if request.PersonID == uuid.Nil {
+		message := "PersonID is invalid"
+		slog.Info("CreateCompanyPersonRequest.validate failed: " + message)
+		return internalErrors.NewValidationError(nil, message)
+	}
+
+	return nil
+}
+
+// ToModel can return ValidationError
+func (request *AssociateCompanyPersonRequest) ToModel() (*models.AssociateCompanyPerson, error) {
+	err := request.validate()
+	if err != nil {
+		return nil, err
+	}
+
+	model := models.AssociateCompanyPerson{
+		CompanyID: request.CompanyID,
+		PersonID:  request.PersonID,
+	}
+
+	return &model, nil
+}
+
+type DeleteCompanyPersonRequest struct {
+	CompanyID uuid.UUID `json:"company_id"`
+	PersonID  uuid.UUID `json:"person_id"`
+}
+
+// validate can return ValidationError
+func (request *DeleteCompanyPersonRequest) validate() error {
+	if request == nil {
+		message := "request is nil"
+		slog.Info("DeleteCompanyPersonRequest.validate failed: " + message)
+		return internalErrors.NewValidationError(nil, message)
+	}
+
+	if request.CompanyID == uuid.Nil {
+		message := "CompanyID is invalid"
+		slog.Info("DeleteCompanyPersonRequest.validate failed: " + message)
+		return internalErrors.NewValidationError(nil, message)
+	}
+
+	if request.PersonID == uuid.Nil {
+		message := "PersonID is invalid"
+		slog.Info("DeleteCompanyPersonRequest.validate failed: " + message)
+		return internalErrors.NewValidationError(nil, message)
+	}
+
+	return nil
+}
+
+// ToModel can return ValidationError
+func (request *DeleteCompanyPersonRequest) ToModel() (*models.DeleteCompanyPerson, error) {
+	if request == nil {
+		return nil, nil
+	}
+
+	err := request.validate()
+	if err != nil {
+		return nil, err
+	}
+
+	model := models.DeleteCompanyPerson{
+		CompanyID: request.CompanyID,
+		PersonID:  request.PersonID,
+	}
+
+	return &model, nil
+}

--- a/internal/api/v1/requests/company_person_requests_test.go
+++ b/internal/api/v1/requests/company_person_requests_test.go
@@ -1,0 +1,139 @@
+package requests
+
+import (
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- AssociateCompanyPersonRequest.validate tests: --------
+
+func TestAssociateCompanyPersonRequestValidate_ShouldValidateRequest(t *testing.T) {
+	request := AssociateCompanyPersonRequest{
+		CompanyID: uuid.New(),
+		PersonID:  uuid.New(),
+	}
+
+	err := request.validate()
+	assert.NoError(t, err)
+}
+
+func TestAssociateCompanyPersonRequestValidate_ShouldReturnValidationErrors(t *testing.T) {
+	tests := []struct {
+		testName             string
+		companyID            uuid.UUID
+		personID             uuid.UUID
+		expectedErrorMessage string
+	}{
+		{
+			"invalid CompanyID",
+			uuid.UUID{},
+			uuid.New(),
+			"validation error: CompanyID is invalid"},
+		{
+			"invalid PersonID",
+			uuid.New(),
+			uuid.UUID{},
+			"validation error: PersonID is invalid"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			request := AssociateCompanyPersonRequest{
+				CompanyID: test.companyID,
+				PersonID:  test.personID,
+			}
+
+			err := request.validate()
+			assert.NotNil(t, err)
+
+			var validationErr *internalErrors.ValidationError
+			assert.True(t, errors.As(err, &validationErr))
+			assert.Equal(t, test.expectedErrorMessage, err.Error())
+		})
+	}
+}
+
+// -------- AssociateCompanyPersonRequest.ToModel tests: --------
+
+func TestAssociateCompanyPersonRequestToModel_ShouldConvertToModel(t *testing.T) {
+	request := AssociateCompanyPersonRequest{
+		CompanyID: uuid.New(),
+		PersonID:  uuid.New(),
+	}
+
+	model, err := request.ToModel()
+	assert.NoError(t, err)
+	assert.NotNil(t, model)
+
+	assert.Equal(t, request.CompanyID, model.CompanyID)
+	assert.Equal(t, request.PersonID, model.PersonID)
+	assert.Nil(t, model.CreatedDate)
+}
+
+// -------- DeleteCompanyPersonRequest.validate tests: --------
+
+func TestDeleteCompanyPersonRequestValidate_ShouldValidateRequest(t *testing.T) {
+	request := DeleteCompanyPersonRequest{
+		CompanyID: uuid.New(),
+		PersonID:  uuid.New(),
+	}
+
+	err := request.validate()
+	assert.NoError(t, err)
+}
+
+func TestDeleteCompanyPersonRequestValidate_ShouldReturnValidationErrors(t *testing.T) {
+	tests := []struct {
+		testName             string
+		companyID            uuid.UUID
+		personID             uuid.UUID
+		expectedErrorMessage string
+	}{
+		{
+			"invalid CompanyID",
+			uuid.UUID{},
+			uuid.New(),
+			"validation error: CompanyID is invalid"},
+		{
+			"invalid PersonID",
+			uuid.New(),
+			uuid.UUID{},
+			"validation error: PersonID is invalid"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			request := DeleteCompanyPersonRequest{
+				CompanyID: test.companyID,
+				PersonID:  test.personID,
+			}
+
+			err := request.validate()
+			assert.NotNil(t, err)
+
+			var validationErr *internalErrors.ValidationError
+			assert.True(t, errors.As(err, &validationErr))
+			assert.Equal(t, test.expectedErrorMessage, err.Error())
+		})
+	}
+}
+
+// -------- DeleteCompanyPersonRequest.ToModel tests: --------
+
+func TestADeleteCompanyPersonRequestToModel_ShouldConvertToModel(t *testing.T) {
+	request := DeleteCompanyPersonRequest{
+		CompanyID: uuid.New(),
+		PersonID:  uuid.New(),
+	}
+
+	model, err := request.ToModel()
+	assert.NoError(t, err)
+	assert.NotNil(t, model)
+
+	assert.Equal(t, request.CompanyID, model.CompanyID)
+	assert.Equal(t, request.PersonID, model.PersonID)
+}

--- a/internal/api/v1/responses/company_person_responses.go
+++ b/internal/api/v1/responses/company_person_responses.go
@@ -1,0 +1,43 @@
+package responses
+
+import (
+	"jobsearchtracker/internal/models"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CompanyPersonResponse struct {
+	CompanyID   uuid.UUID `json:"company_id"`
+	PersonID    uuid.UUID `json:"person_id"`
+	CreatedDate time.Time `json:"created_date"`
+}
+
+func NewCompanyPersonResponse(model *models.CompanyPerson) *CompanyPersonResponse {
+	if model == nil {
+		return nil
+	}
+
+	response := &CompanyPersonResponse{
+		CompanyID:   model.CompanyID,
+		PersonID:    model.PersonID,
+		CreatedDate: model.CreatedDate,
+	}
+
+	return response
+}
+
+func NewCompanyPersonsResponse(models []*models.CompanyPerson) []*CompanyPersonResponse {
+	if models == nil || len(models) == 0 {
+		return []*CompanyPersonResponse{}
+	}
+
+	var responses = make([]*CompanyPersonResponse, len(models))
+	for index := range models {
+		response := NewCompanyPersonResponse(models[index])
+
+		responses[index] = response
+	}
+
+	return responses
+}

--- a/internal/api/v1/responses/company_person_responses_test.go
+++ b/internal/api/v1/responses/company_person_responses_test.go
@@ -1,0 +1,73 @@
+package responses
+
+import (
+	"jobsearchtracker/internal/models"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- NewCompanyPersonResponse tests: --------
+
+func TestNewCompanyPersonResponse_ShouldWork(t *testing.T) {
+	model := models.CompanyPerson{
+		PersonID:    uuid.New(),
+		CompanyID:   uuid.New(),
+		CreatedDate: time.Now().AddDate(1, 2, 3),
+	}
+
+	response := NewCompanyPersonResponse(&model)
+	assert.NotNil(t, response)
+
+	assert.Equal(t, response.CompanyID, model.CompanyID)
+	assert.Equal(t, response.PersonID.String(), model.PersonID.String())
+	assert.Equal(t, response.CreatedDate, model.CreatedDate)
+}
+
+func TestNewCompanyPersonResponse_ReturnNilIfModelIsNil(t *testing.T) {
+	response := NewCompanyPersonResponse(nil)
+	assert.Nil(t, response)
+}
+
+// -------- NewCompanyPersonsResponse tests: --------
+
+func TestNewCompanyPersonsResponse_ShouldWork(t *testing.T) {
+	companyPersonModels := []*models.CompanyPerson{
+		{
+			PersonID:    uuid.New(),
+			CompanyID:   uuid.New(),
+			CreatedDate: time.Now().AddDate(1, 2, 3),
+		},
+		{
+			PersonID:    uuid.New(),
+			CompanyID:   uuid.New(),
+			CreatedDate: time.Now().AddDate(4, 5, 6),
+		},
+	}
+
+	response := NewCompanyPersonsResponse(companyPersonModels)
+	assert.NotNil(t, response)
+	assert.Equal(t, 2, len(response))
+
+	assert.Equal(t, response[0].CompanyID, companyPersonModels[0].CompanyID)
+	assert.Equal(t, response[0].PersonID, companyPersonModels[0].PersonID)
+	assert.Equal(t, response[0].CreatedDate, companyPersonModels[0].CreatedDate)
+
+	assert.Equal(t, response[1].CompanyID, companyPersonModels[1].CompanyID)
+	assert.Equal(t, response[1].PersonID, companyPersonModels[1].PersonID)
+	assert.Equal(t, response[1].CreatedDate, companyPersonModels[1].CreatedDate)
+}
+
+func TestNewCompanyPersonsResponse_ShouldReturnEmptySliceIfModelIsEmpty(t *testing.T) {
+	response := NewCompanyPersonsResponse([]*models.CompanyPerson{})
+	assert.NotNil(t, response)
+	assert.Equal(t, 0, len(response))
+}
+
+func TestNewCompanyPersonsResponse_ShouldReturnEmptySliceIfModelIsNil(t *testing.T) {
+	response := NewCompanyPersonsResponse(nil)
+	assert.NotNil(t, response)
+	assert.Equal(t, 0, len(response))
+}

--- a/internal/models/company_person.go
+++ b/internal/models/company_person.go
@@ -1,0 +1,51 @@
+package models
+
+import (
+	"jobsearchtracker/internal/errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CompanyPerson struct {
+	CompanyID   uuid.UUID
+	PersonID    uuid.UUID
+	CreatedDate time.Time
+}
+
+type AssociateCompanyPerson struct {
+	CompanyID   uuid.UUID
+	PersonID    uuid.UUID
+	CreatedDate *time.Time
+}
+
+// Validate can return ValidationError
+func (companyPerson *AssociateCompanyPerson) Validate() error {
+	if companyPerson.CompanyID == uuid.Nil {
+		return errors.NewValidationError(nil, "CompanyID is empty")
+	}
+
+	if companyPerson.PersonID == uuid.Nil {
+		return errors.NewValidationError(nil, "PersonID is empty")
+	}
+
+	return nil
+}
+
+type DeleteCompanyPerson struct {
+	CompanyID uuid.UUID
+	PersonID  uuid.UUID
+}
+
+// Validate can return ValidationError
+func (companyPerson *DeleteCompanyPerson) Validate() error {
+	if companyPerson.CompanyID == uuid.Nil {
+		return errors.NewValidationError(nil, "CompanyID cannot be empty")
+	}
+
+	if companyPerson.PersonID == uuid.Nil {
+		return errors.NewValidationError(nil, "PersonID cannot be empty")
+	}
+
+	return nil
+}

--- a/internal/models/company_person_test.go
+++ b/internal/models/company_person_test.go
@@ -1,0 +1,113 @@
+package models
+
+import (
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/testutil"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- AssociateCompanyPerson.Validate tests: --------
+
+func TestAssociateCompanyPersonValidate_ShouldReturnNilIfAssociateCompanyPersonIsValid(t *testing.T) {
+	model := AssociateCompanyPerson{
+		CompanyID:   uuid.New(),
+		PersonID:    uuid.New(),
+		CreatedDate: testutil.ToPtr(time.Now()),
+	}
+
+	err := model.Validate()
+	assert.NoError(t, err)
+}
+
+func TestAssociateCompanyPersonValidate_ShouldReturnNilIfOnlyRequiredFieldsExist(t *testing.T) {
+	model := AssociateCompanyPerson{
+		CompanyID: uuid.New(),
+		PersonID:  uuid.New(),
+	}
+
+	err := model.Validate()
+	assert.NoError(t, err)
+}
+
+func TestAssociateCompanyPersonValidate_ShouldReturnValidationErrorIfCompanyIDIsEmpty(t *testing.T) {
+	var companyID uuid.UUID
+	model := AssociateCompanyPerson{
+		CompanyID:   companyID,
+		PersonID:    uuid.New(),
+		CreatedDate: testutil.ToPtr(time.Now()),
+	}
+
+	err := model.Validate()
+	assert.NotNil(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: CompanyID is empty", validationErr.Error())
+
+}
+
+func TestAssociateCompanyPersonValidate_ShouldReturnValidationErrorIfPersonIDIsEmpty(t *testing.T) {
+	var personID uuid.UUID
+	model := AssociateCompanyPerson{
+		CompanyID:   uuid.New(),
+		PersonID:    personID,
+		CreatedDate: testutil.ToPtr(time.Now()),
+	}
+
+	err := model.Validate()
+	assert.NotNil(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: PersonID is empty", validationErr.Error())
+
+}
+
+// -------- DeleteCompanyPerson.Validate tests: --------
+
+func TestDeleteCompanyPersonValidate_ShouldReturnNilIfAssociateCompanyPersonIsValid(t *testing.T) {
+	model := DeleteCompanyPerson{
+		CompanyID: uuid.New(),
+		PersonID:  uuid.New(),
+	}
+
+	err := model.Validate()
+	assert.NoError(t, err)
+}
+
+func TestDeleteCompanyPersonValidate_ShouldReturnValidationErrorIfCompanyIDIsEmpty(t *testing.T) {
+	var companyID uuid.UUID
+	model := DeleteCompanyPerson{
+		CompanyID: companyID,
+		PersonID:  uuid.New(),
+	}
+
+	err := model.Validate()
+	assert.NotNil(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: CompanyID cannot be empty", validationErr.Error())
+
+}
+
+func TestDeleteCompanyPersonValidate_ShouldReturnValidationErrorIfPersonIDIsEmpty(t *testing.T) {
+	var personID uuid.UUID
+	model := DeleteCompanyPerson{
+		CompanyID: uuid.New(),
+		PersonID:  personID,
+	}
+
+	err := model.Validate()
+	assert.NotNil(t, err)
+
+	var validationErr *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationErr))
+	assert.Equal(t, "validation error: PersonID cannot be empty", validationErr.Error())
+
+}

--- a/internal/repositories/application_repository_integration_test.go
+++ b/internal/repositories/application_repository_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"jobsearchtracker/internal/models"
 	"jobsearchtracker/internal/repositories"
 	"jobsearchtracker/internal/testutil/dependencyinjection"
+	"jobsearchtracker/internal/testutil/repositoryhelpers"
 	"testing"
 	"time"
 
@@ -42,8 +43,8 @@ func setupApplicationRepository(t *testing.T) (*repositories.ApplicationReposito
 func TestCreate_ShouldInsertAndReturnApplication(t *testing.T) {
 	applicationRepository, companyRepository := setupApplicationRepository(t)
 
-	companyID := createCompany(t, companyRepository)
-	recruiterID := createCompany(t, companyRepository)
+	companyID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
+	recruiterID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
 
 	id := uuid.New()
 	jobTitle := "Job Title"
@@ -106,7 +107,7 @@ func TestCreate_ShouldInsertAndReturnApplication(t *testing.T) {
 func TestCreate_ShouldInsertAndReturnWithMinimumRequiredFields(t *testing.T) {
 	applicationRepository, companyRepository := setupApplicationRepository(t)
 
-	companyID := createCompany(t, companyRepository)
+	companyID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
 
 	jobAdURL := "Job Ad URL"
 	application := models.CreateApplication{
@@ -203,7 +204,7 @@ func TestCreate_ShouldReturnErrorIfRecruiterIDIsNotInCompany(t *testing.T) {
 func TestCreate_ShouldReturnErrorIfJobTitleAndJobAdURLIsNil(t *testing.T) {
 	applicationRepository, companyRepository := setupApplicationRepository(t)
 
-	companyID := createCompany(t, companyRepository)
+	companyID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
 
 	createApplication := models.CreateApplication{
 		CompanyID:        companyID,
@@ -227,8 +228,8 @@ func TestCreate_ShouldReturnErrorIfJobTitleAndJobAdURLIsNil(t *testing.T) {
 func TestGetById_ShouldGetApplication(t *testing.T) {
 	applicationRepository, companyRepository := setupApplicationRepository(t)
 
-	companyID := createCompany(t, companyRepository)
-	recruiterID := createCompany(t, companyRepository)
+	companyID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
+	recruiterID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
 
 	id := uuid.New()
 	jobTitle := "Job Title"
@@ -317,7 +318,7 @@ func TestGetById_ShouldReturnErrorIfApplicationIDDoesNotExist(t *testing.T) {
 func TestGetAllByJobTitle_ShouldReturnApplication(t *testing.T) {
 	applicationRepository, companyRepository := setupApplicationRepository(t)
 
-	recruiterID := createCompany(t, companyRepository)
+	recruiterID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
 	jobTitle := "Some Job Title"
 
 	applicationToInsert := models.CreateApplication{
@@ -364,7 +365,7 @@ func TestGetAllByJobTitle_ShouldReturnMultipleApplicationsWithSameJobTitle(t *te
 	// insert some applications
 
 	application1ID := uuid.New()
-	application1CompanyID := createCompany(t, companyRepository)
+	application1CompanyID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
 	application1JobTitle := "Developer"
 	application1 := models.CreateApplication{
 		ID:               &application1ID,
@@ -377,7 +378,7 @@ func TestGetAllByJobTitle_ShouldReturnMultipleApplicationsWithSameJobTitle(t *te
 	assert.NotNil(t, insertedApplication1)
 
 	application2ID := uuid.New()
-	application2RecruiterID := createCompany(t, companyRepository)
+	application2RecruiterID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
 	application2JobTitle := "Software Engineer"
 	application2 := models.CreateApplication{
 		ID:               &application2ID,
@@ -390,7 +391,7 @@ func TestGetAllByJobTitle_ShouldReturnMultipleApplicationsWithSameJobTitle(t *te
 	assert.NotNil(t, insertedApplication2)
 
 	application3ID := uuid.New()
-	application3CompanyID := createCompany(t, companyRepository)
+	application3CompanyID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
 	application3JobTitle := "Backend Developer"
 	application3 := models.CreateApplication{
 		ID:               &application3ID,
@@ -420,8 +421,8 @@ func TestGetAllByJobTitle_ShouldReturnMultipleApplicationsWithSameJobTitle(t *te
 
 func TestGetAll_ShouldReturnAllApplications(t *testing.T) {
 	applicationRepository, companyRepository := setupApplicationRepository(t)
-	companyID := createCompany(t, companyRepository)
-	recruiterID := createCompany(t, companyRepository)
+	companyID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
+	recruiterID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
 
 	id1 := uuid.New()
 	jobTitle1 := "Job Title1"
@@ -512,8 +513,8 @@ func TestGetAll_ShouldReturnNilIfNoApplicationsInDatabase(t *testing.T) {
 func TestUpdate_ShouldUpdateApplication(t *testing.T) {
 	applicationRepository, companyRepository := setupApplicationRepository(t)
 
-	companyID := createCompany(t, companyRepository)
-	recruiterID := createCompany(t, companyRepository)
+	companyID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
+	recruiterID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
 
 	// create an application
 	id := uuid.New()
@@ -548,8 +549,8 @@ func TestUpdate_ShouldUpdateApplication(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, insertedApplication)
 
-	newCompanyID := createCompany(t, companyRepository)
-	newRecruiterID := createCompany(t, companyRepository)
+	newCompanyID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
+	newRecruiterID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
 
 	newJobTitle := "New Job Title"
 	newJobAdURL := "New Job Ad URL"
@@ -618,7 +619,10 @@ func TestUpdate_ShouldReturnValidationErrorIfNoApplicationFieldsToUpdate(t *test
 
 	err := applicationRepository.Update(&applicationToUpdate)
 	assert.Error(t, err)
-	assert.Equal(t, "validation error: nothing to update", err.Error())
+
+	var validationError *internalErrors.ValidationError
+	assert.True(t, errors.As(err, &validationError))
+	assert.Equal(t, "validation error: nothing to update", validationError)
 }
 
 func TestUpdate_ShouldNotReturnErrorIfApplicationDoesNotExist(t *testing.T) {
@@ -641,7 +645,7 @@ func TestUpdate_ShouldNotReturnErrorIfApplicationDoesNotExist(t *testing.T) {
 func TestDelete_ShouldDeleteApplication(t *testing.T) {
 	applicationRepository, companyRepository := setupApplicationRepository(t)
 
-	recruiterID := createCompany(t, companyRepository)
+	recruiterID := &repositoryhelpers.CreateCompany(t, companyRepository, nil, nil).ID
 
 	id := uuid.New()
 	jobTitle := "JobTitle"
@@ -681,18 +685,3 @@ func TestDelete_ShouldReturnNotFoundErrorIfApplicationIdDoesNotExist(t *testing.
 }
 
 // -------- Test helpers: --------
-
-func createCompany(t *testing.T, companyRepository *repositories.CompanyRepository) *uuid.UUID {
-
-	id := uuid.New()
-	company := models.CreateCompany{
-		ID:          &id,
-		Name:        "Example Company Name",
-		CompanyType: models.CompanyTypeEmployer,
-	}
-
-	insertedCompany, err := companyRepository.Create(&company)
-	assert.NoError(t, err)
-
-	return &insertedCompany.ID
-}

--- a/internal/repositories/company_person_repository.go
+++ b/internal/repositories/company_person_repository.go
@@ -1,0 +1,237 @@
+package repositories
+
+import (
+	"database/sql"
+	"errors"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CompanyPersonRepository struct {
+	database *sql.DB
+}
+
+func NewCompanyPersonRepository(database *sql.DB) *CompanyPersonRepository {
+	return &CompanyPersonRepository{database: database}
+}
+
+// AssociateCompanyPerson can return ConflictError, InternalServiceError
+func (repository *CompanyPersonRepository) AssociateCompanyPerson(
+	associateModel *models.AssociateCompanyPerson) (*models.CompanyPerson, error) {
+
+	sqlInsert := `
+			INSERT INTO company_person (
+				company_id, person_id, created_date
+			) VALUES (
+				?, ?, ?
+		  	) RETURNING company_id, person_id, created_date;
+		`
+
+	var createdDate string
+	if associateModel.CreatedDate != nil {
+		createdDate = associateModel.CreatedDate.Format(time.RFC3339)
+	} else {
+		createdDate = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	row := repository.database.QueryRow(
+		sqlInsert,
+		associateModel.CompanyID,
+		associateModel.PersonID,
+		createdDate,
+	)
+
+	if row.Err() != nil {
+		if row.Err().Error() ==
+			"constraint failed: UNIQUE constraint failed: company_person.company_id, company_person.person_id (1555)" {
+			slog.Info(
+				"company_person_repository.associateToCompany: UNIQUE constraint failed",
+				"company_id", associateModel.CompanyID,
+				"person_id", associateModel.PersonID)
+			return nil, internalErrors.NewConflictError(
+				"CompanyID and PersonID combination already exists in database.")
+		} else if row.Err().Error() == "constraint failed: FOREIGN KEY constraint failed (787)" {
+			// TODO: Use foreign key constraint names (in 0003_add_application.up.sql) once modernc.org/sqlite
+			// supports it.
+			slog.Info("company_person_repository.Create: FOREIGN KEY constraint failed (787)")
+			return nil, internalErrors.NewValidationError(nil, "Foreign key does not exist")
+		}
+		return nil, row.Err()
+	}
+
+	// can return InternalServiceError
+	result, err := repository.mapRow(row, "Create")
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			slog.Info("company_person_repository.create: No result found.", "error", err.Error())
+			return nil, internalErrors.NewNotFoundError("Unable to map CompanyPerson")
+		}
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetByID can return ValidationError, InternalServiceError
+func (repository *CompanyPersonRepository) GetByID(
+	companyID *uuid.UUID, personID *uuid.UUID) ([]*models.CompanyPerson, error) {
+
+	if (companyID == nil || *companyID == uuid.Nil) && (personID == nil || *personID == uuid.Nil) {
+		return nil, internalErrors.NewValidationError(nil, "companyID and personID cannot both be empty")
+	}
+
+	sqlSelect := `
+		SELECT company_id, person_id, created_date
+		FROM company_person WHERE
+	`
+
+	var args []interface{}
+	companyIDAdded := false
+	if companyID != nil && *companyID != uuid.Nil {
+		sqlSelect += " company_id = ? "
+		args = append(args, companyID)
+		companyIDAdded = true
+	}
+
+	if personID != nil && *personID != uuid.Nil {
+		if companyIDAdded {
+			sqlSelect += " AND "
+		}
+		sqlSelect += " person_id = ? "
+		args = append(args, personID)
+	}
+
+	sqlSelect += " ORDER BY created_date DESC"
+
+	rows, err := repository.database.Query(sqlSelect, args...)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var results []*models.CompanyPerson
+	for rows.Next() {
+		// mapRow can return InternalServiceError
+		result, err := repository.mapRow(rows, "getByID")
+		if err != nil {
+			slog.Error("company_person_repository.getByID: Error mapping row", "error", err)
+			return nil, internalErrors.NewInternalServiceError("Error processing person data: " + err.Error())
+		}
+
+		if result != nil {
+			results = append(results, result)
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		slog.Error("company_person_repository.getByID: Error iterating rows", "error", err)
+		return nil, internalErrors.NewInternalServiceError(
+			"Error reading PersonCompanies from database: " + err.Error())
+	}
+
+	return results, nil
+}
+
+// GetAll can return InternalServiceError
+func (repository *CompanyPersonRepository) GetAll() ([]*models.CompanyPerson, error) {
+	sqlSelect := "SELECT company_id, person_id, created_date FROM company_person ORDER BY created_date DESC;"
+
+	rows, err := repository.database.Query(sqlSelect)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var results []*models.CompanyPerson
+	for rows.Next() {
+		// mapRow can return InternalServiceError
+		result, err := repository.mapRow(rows, "GetAll")
+		if err != nil {
+			slog.Error("company_person_repository.GetAll: Error mapping row", "error", err)
+			return nil, internalErrors.NewInternalServiceError("Error processing person data: " + err.Error())
+		}
+
+		if result != nil {
+			results = append(results, result)
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		slog.Error("company_person_repository.GetAll: Error iterating rows", "error", err)
+		return nil, internalErrors.NewInternalServiceError(
+			"Error reading PersonCompanies from database: " + err.Error())
+	}
+
+	return results, nil
+}
+
+// Delete can return InternalServiceError, NotFoundError
+func (repository *CompanyPersonRepository) Delete(model *models.DeleteCompanyPerson) error {
+	sqlDelete := "DELETE FROM company_person WHERE company_id = ? AND person_id = ?;"
+
+	result, err := repository.database.Exec(sqlDelete, model.CompanyID, model.PersonID)
+	if err != nil {
+		slog.Error(
+			"company_person_repository.Delete: Error trying to delete CompanyPerson",
+			"companyID", model.CompanyID,
+			"personID", model.PersonID,
+			"error", err.Error())
+		return internalErrors.NewInternalServiceError(err.Error())
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		slog.Error(
+			"company_person_repository.Delete: Error trying to delete CompanyPerson",
+			"companyID", model.CompanyID,
+			"personID", model.PersonID,
+			"error", err.Error())
+		return internalErrors.NewInternalServiceError(err.Error())
+	}
+	if rowsAffected == 0 {
+		return internalErrors.NewNotFoundError(
+			"CompanyPerson does not exist. companyID: " + model.CompanyID.String() +
+				", personID: " + model.PersonID.String())
+	} else if rowsAffected > 1 {
+		return internalErrors.NewInternalServiceError(
+			"Unexpected number of rows affected: " + strconv.FormatInt(rowsAffected, 10))
+	}
+
+	return nil
+}
+
+// mapRow can return InternalServiceError
+func (repository *CompanyPersonRepository) mapRow(scanner interface{ Scan(...interface{}) error },
+	methodName string) (*models.CompanyPerson, error) {
+
+	var result models.CompanyPerson
+	var createdDate sql.NullString
+
+	err := scanner.Scan(&result.CompanyID, &result.PersonID, &createdDate)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if createdDate.Valid {
+		timestamp, err := time.Parse(time.RFC3339, createdDate.String)
+		if err != nil {
+			slog.Error("company_person_repository."+methodName+": Error parsing createdDate",
+				"createdDate", createdDate,
+				"error", err.Error())
+			return nil, internalErrors.NewInternalServiceError("Error parsing createdDate: " + err.Error())
+		}
+		result.CreatedDate = timestamp
+	}
+
+	return &result, nil
+}

--- a/internal/repositories/company_person_repository_integration_test.go
+++ b/internal/repositories/company_person_repository_integration_test.go
@@ -1,0 +1,602 @@
+package repositories_test
+
+import (
+	"errors"
+	configPackage "jobsearchtracker/internal/config"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/repositories"
+	"jobsearchtracker/internal/testutil"
+	"jobsearchtracker/internal/testutil/dependencyinjection"
+	"jobsearchtracker/internal/testutil/repositoryhelpers"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupCompanyPersonRepository(t *testing.T) (
+	*repositories.CompanyPersonRepository, *repositories.CompanyRepository, *repositories.PersonRepository) {
+
+	config := &configPackage.Config{
+		DatabaseMigrationsPath:               "../../migrations",
+		IsDatabaseMigrationsPathAbsolutePath: false,
+	}
+
+	container := dependencyinjection.SetupCompanyPersonRepositoryTestContainer(t, *config)
+
+	var companyPersonRepository *repositories.CompanyPersonRepository
+	err := container.Invoke(func(repository *repositories.CompanyPersonRepository) {
+		companyPersonRepository = repository
+	})
+	assert.NoError(t, err)
+
+	var companyRepository *repositories.CompanyRepository
+	err = container.Invoke(func(repository *repositories.CompanyRepository) {
+		companyRepository = repository
+	})
+
+	var personRepository *repositories.PersonRepository
+	err = container.Invoke(func(repository *repositories.PersonRepository) {
+		personRepository = repository
+	})
+	assert.NoError(t, err)
+
+	return companyPersonRepository, companyRepository, personRepository
+}
+
+// -------- AssociateCompanyPerson tests: --------
+
+func TestAssociateCompanyToPerson_ShouldWork(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	person := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson := models.AssociateCompanyPerson{
+		CompanyID:   company.ID,
+		PersonID:    person.ID,
+		CreatedDate: testutil.ToPtr(time.Now()),
+	}
+	associatedCompanyPerson, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson)
+	assert.NoError(t, err)
+	assert.NotNil(t, associatedCompanyPerson)
+
+	assert.Equal(t, company.ID, associatedCompanyPerson.CompanyID)
+	assert.Equal(t, person.ID, associatedCompanyPerson.PersonID)
+
+	createdDateToInsert := companyPerson.CreatedDate.Format(time.RFC3339)
+	insertedCreatedDate := associatedCompanyPerson.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, createdDateToInsert, insertedCreatedDate)
+}
+
+func TestAssociateCompanyToPerson_ShouldWorkWithOnlyRequiredFields(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	person := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson := models.AssociateCompanyPerson{
+		CompanyID: company.ID,
+		PersonID:  person.ID,
+	}
+	associatedCompanyPerson, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson)
+	assert.NoError(t, err)
+	assert.NotNil(t, associatedCompanyPerson)
+
+	assert.Equal(t, company.ID, associatedCompanyPerson.CompanyID)
+	assert.Equal(t, person.ID, associatedCompanyPerson.PersonID)
+	assert.NotNil(t, associatedCompanyPerson.CreatedDate)
+}
+
+func TestAssociateCompanyToPerson_ShouldAssociateACompanyToMultiplePersons(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	person2 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := models.AssociateCompanyPerson{
+		CompanyID:   company.ID,
+		PersonID:    person1.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 1)),
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson1)
+	assert.NoError(t, err)
+
+	companyPerson2 := models.AssociateCompanyPerson{
+		CompanyID:   company.ID,
+		PersonID:    person2.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 2)),
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson2)
+	assert.NoError(t, err)
+
+	personCompanies, err := companyPersonRepository.GetAll()
+	assert.NoError(t, err)
+	assert.NotNil(t, personCompanies)
+	assert.Len(t, personCompanies, 2)
+
+	associatedCompanyPerson1 := personCompanies[0]
+	assert.Equal(t, company.ID, associatedCompanyPerson1.CompanyID)
+	assert.Equal(t, person2.ID, associatedCompanyPerson1.PersonID)
+	assert.NotNil(t, associatedCompanyPerson1.CreatedDate)
+
+	associatedCompanyPerson2 := personCompanies[1]
+	assert.Equal(t, company.ID, associatedCompanyPerson2.CompanyID)
+	assert.Equal(t, person1.ID, associatedCompanyPerson2.PersonID)
+	assert.NotNil(t, associatedCompanyPerson2.CreatedDate)
+}
+
+func TestAssociateCompanyToPerson_ShouldAssociateMultipleCompaniesToAPerson(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	company2 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	person := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := models.AssociateCompanyPerson{
+		CompanyID:   company1.ID,
+		PersonID:    person.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 1)),
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson1)
+	assert.NoError(t, err)
+
+	companyPerson2 := models.AssociateCompanyPerson{
+		CompanyID:   company2.ID,
+		PersonID:    person.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 2)),
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson2)
+	assert.NoError(t, err)
+
+	personCompanies, err := companyPersonRepository.GetAll()
+	assert.NoError(t, err)
+	assert.NotNil(t, personCompanies)
+	assert.Len(t, personCompanies, 2)
+
+	associatedCompanyPerson1 := personCompanies[0]
+	assert.Equal(t, company2.ID, associatedCompanyPerson1.CompanyID)
+	assert.Equal(t, person.ID, associatedCompanyPerson1.PersonID)
+	assert.NotNil(t, associatedCompanyPerson1.CreatedDate)
+
+	associatedCompanyPerson2 := personCompanies[1]
+	assert.Equal(t, company1.ID, associatedCompanyPerson2.CompanyID)
+	assert.Equal(t, person.ID, associatedCompanyPerson2.PersonID)
+	assert.NotNil(t, associatedCompanyPerson2.CreatedDate)
+}
+
+func TestAssociateCompanyToPerson_ShouldReturnConflictErrorIfCompanyIDAndPersonIDCombinationAlreadyExist(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	person := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson := models.AssociateCompanyPerson{
+		CompanyID: company.ID,
+		PersonID:  person.ID,
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson)
+	assert.NoError(t, err)
+
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson)
+	assert.NotNil(t, err)
+
+	assert.Equal(
+		t,
+		"conflict error on insert: CompanyID and PersonID combination already exists in database.",
+		err.Error())
+}
+
+func TestAssociateCompanyToPerson_ShouldReturnValidationErrorIfPersonIDDoesNotExist(t *testing.T) {
+	companyPersonRepository, companyRepository, _ := setupCompanyPersonRepository(t)
+
+	company := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+
+	companyPerson := models.AssociateCompanyPerson{
+		CompanyID: company.ID,
+		PersonID:  uuid.New(),
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson)
+	assert.NotNil(t, err)
+	assert.Equal(t, "validation error: Foreign key does not exist", err.Error())
+}
+
+func TestAssociateCompanyToPerson_ShouldReturnValidationErrorIfCompanyIDDoesNotExist(t *testing.T) {
+	companyPersonRepository, _, personRepository := setupCompanyPersonRepository(t)
+
+	person := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson := models.AssociateCompanyPerson{
+		CompanyID: uuid.New(),
+		PersonID:  person.ID,
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson)
+	assert.NotNil(t, err)
+	assert.Equal(t, "validation error: Foreign key does not exist", err.Error())
+}
+
+func TestAssociateCompanyToPerson_ShouldReturnValidationErrorIfCompanyIDAndPersonIDDoNotExist(t *testing.T) {
+	companyPersonRepository, _, _ := setupCompanyPersonRepository(t)
+
+	companyPerson := models.AssociateCompanyPerson{
+		CompanyID: uuid.New(),
+		PersonID:  uuid.New(),
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson)
+	assert.NotNil(t, err)
+	assert.Equal(t, "validation error: Foreign key does not exist", err.Error())
+}
+
+// -------- GetByID tests: --------
+
+func TestGetByID_ShouldGetRecordsMatchingCompanyID(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	company2 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	person2 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := models.AssociateCompanyPerson{
+		CompanyID:   company1.ID,
+		PersonID:    person1.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 1)),
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson1)
+	assert.NoError(t, err)
+
+	companyPerson2 := models.AssociateCompanyPerson{
+		CompanyID:   company1.ID,
+		PersonID:    person2.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 2)),
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson2)
+	assert.NoError(t, err)
+
+	companyPerson3 := models.AssociateCompanyPerson{
+		CompanyID:   company2.ID,
+		PersonID:    person1.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 3)),
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson3)
+	assert.NoError(t, err)
+
+	companyPersons, err := companyPersonRepository.GetByID(&company1.ID, nil)
+	assert.NoError(t, err)
+	assert.Len(t, companyPersons, 2)
+
+	assert.Equal(t, companyPersons[0].CompanyID, company1.ID)
+	assert.Equal(t, companyPersons[0].PersonID, person2.ID)
+
+	assert.Equal(t, companyPersons[1].CompanyID, company1.ID)
+	assert.Equal(t, companyPersons[1].PersonID, person1.ID)
+}
+
+func TestGetByID_ShouldGetRecordsMatchingPersonID(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	company2 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	person2 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := models.AssociateCompanyPerson{
+		CompanyID:   company1.ID,
+		PersonID:    person1.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 1)),
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson1)
+	assert.NoError(t, err)
+
+	companyPerson2 := models.AssociateCompanyPerson{
+		CompanyID:   company1.ID,
+		PersonID:    person2.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 2)),
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson2)
+	assert.NoError(t, err)
+
+	companyPerson3 := models.AssociateCompanyPerson{
+		CompanyID:   company2.ID,
+		PersonID:    person1.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 3)),
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson3)
+	assert.NoError(t, err)
+
+	companyPersons, err := companyPersonRepository.GetByID(nil, &person1.ID)
+	assert.NoError(t, err)
+	assert.Len(t, companyPersons, 2)
+
+	assert.Equal(t, companyPersons[0].CompanyID, company2.ID)
+	assert.Equal(t, companyPersons[0].PersonID, person1.ID)
+
+	assert.Equal(t, companyPersons[1].CompanyID, company1.ID)
+	assert.Equal(t, companyPersons[1].PersonID, person1.ID)
+}
+
+func TestGetByID_ShouldGetRecordsMatchingCompanyIDAndPersonID(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	company2 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	person2 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := models.AssociateCompanyPerson{
+		CompanyID: company1.ID,
+		PersonID:  person1.ID,
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson1)
+	assert.NoError(t, err)
+
+	companyPerson2 := models.AssociateCompanyPerson{
+		CompanyID: company1.ID,
+		PersonID:  person2.ID,
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson2)
+	assert.NoError(t, err)
+
+	companyPerson3 := models.AssociateCompanyPerson{
+		CompanyID: company2.ID,
+		PersonID:  person1.ID,
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson3)
+	assert.NoError(t, err)
+
+	persons, err := companyPersonRepository.GetByID(&company1.ID, &person1.ID)
+	assert.NoError(t, err)
+	assert.Len(t, persons, 1)
+	assert.Equal(t, company1.ID, persons[0].CompanyID)
+	assert.Equal(t, person1.ID, persons[0].PersonID)
+}
+
+func TestGetByID_ShouldGetNoRecordsIfCompanyIDDoesNotMatch(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	company2 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	person2 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := models.AssociateCompanyPerson{
+		CompanyID: company1.ID,
+		PersonID:  person1.ID,
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson1)
+	assert.NoError(t, err)
+
+	companyPerson2 := models.AssociateCompanyPerson{
+		CompanyID: company1.ID,
+		PersonID:  person2.ID,
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson2)
+	assert.NoError(t, err)
+
+	companyPerson3 := models.AssociateCompanyPerson{
+		CompanyID: company2.ID,
+		PersonID:  person1.ID,
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson3)
+	assert.NoError(t, err)
+
+	persons, err := companyPersonRepository.GetByID(testutil.ToPtr(uuid.New()), &person1.ID)
+	assert.NoError(t, err)
+	assert.Nil(t, persons)
+}
+
+func TestGetByID_ShouldGetNoRecordsIfPersonIDDoesNotMatch(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	company2 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	person2 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := models.AssociateCompanyPerson{
+		CompanyID: company1.ID,
+		PersonID:  person1.ID,
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson1)
+	assert.NoError(t, err)
+
+	companyPerson2 := models.AssociateCompanyPerson{
+		CompanyID: company1.ID,
+		PersonID:  person2.ID,
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson2)
+	assert.NoError(t, err)
+
+	companyPerson3 := models.AssociateCompanyPerson{
+		CompanyID: company2.ID,
+		PersonID:  person1.ID,
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson3)
+	assert.NoError(t, err)
+
+	persons, err := companyPersonRepository.GetByID(&company1.ID, testutil.ToPtr(uuid.New()))
+	assert.NoError(t, err)
+	assert.Nil(t, persons)
+}
+
+func TestGetByID_ShouldGetNoRecordsIfCompanyIDAndPersonIDDoesNotMatch(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	company2 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	person2 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := models.AssociateCompanyPerson{
+		CompanyID: company1.ID,
+		PersonID:  person1.ID,
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson1)
+	assert.NoError(t, err)
+
+	companyPerson2 := models.AssociateCompanyPerson{
+		CompanyID: company1.ID,
+		PersonID:  person2.ID,
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson2)
+	assert.NoError(t, err)
+
+	companyPerson3 := models.AssociateCompanyPerson{
+		CompanyID: company2.ID,
+		PersonID:  person1.ID,
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson3)
+	assert.NoError(t, err)
+
+	persons, err := companyPersonRepository.GetByID(testutil.ToPtr(uuid.New()), testutil.ToPtr(uuid.New()))
+	assert.NoError(t, err)
+	assert.Nil(t, persons)
+}
+
+func TestGetByID_ShouldGetNoRecordsIfNoRecordsInDB(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	persons, err := companyPersonRepository.GetByID(&company1.ID, &person1.ID)
+	assert.NoError(t, err)
+	assert.Nil(t, persons)
+}
+
+// -------- GetAll tests: --------
+
+func TestGetAllCompanyPersons_ShouldReturnAllCompanyPersons(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	company2 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	person2 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := models.AssociateCompanyPerson{
+		CompanyID:   company1.ID,
+		PersonID:    person1.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 1)),
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson1)
+	assert.NoError(t, err)
+
+	companyPerson2 := models.AssociateCompanyPerson{
+		CompanyID:   company1.ID,
+		PersonID:    person2.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 3)),
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson2)
+	assert.NoError(t, err)
+
+	companyPerson3 := models.AssociateCompanyPerson{
+		CompanyID:   company2.ID,
+		PersonID:    person2.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 2)),
+	}
+	_, err = companyPersonRepository.AssociateCompanyPerson(&companyPerson3)
+	assert.NoError(t, err)
+
+	personCompanies, err := companyPersonRepository.GetAll()
+	assert.NoError(t, err)
+
+	assert.Len(t, personCompanies, 3)
+
+	insertedCompanyPerson1 := personCompanies[0]
+	assert.Equal(t, company1.ID, insertedCompanyPerson1.CompanyID)
+	assert.Equal(t, person2.ID, insertedCompanyPerson1.PersonID)
+
+	createdDateToInsert1 := companyPerson2.CreatedDate.Format(time.RFC3339)
+	insertedCreatedDate1 := insertedCompanyPerson1.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, createdDateToInsert1, insertedCreatedDate1)
+
+	insertedCompanyPerson2 := personCompanies[1]
+	assert.Equal(t, company2.ID, insertedCompanyPerson2.CompanyID)
+	assert.Equal(t, person2.ID, insertedCompanyPerson2.PersonID)
+
+	createdDateToInsert2 := companyPerson3.CreatedDate.Format(time.RFC3339)
+	insertedCreatedDate2 := insertedCompanyPerson2.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, createdDateToInsert2, insertedCreatedDate2)
+
+	insertedCompanyPerson3 := personCompanies[2]
+	assert.Equal(t, company1.ID, insertedCompanyPerson3.CompanyID)
+	assert.Equal(t, person1.ID, insertedCompanyPerson3.PersonID)
+
+	createdDateToInsert3 := companyPerson1.CreatedDate.Format(time.RFC3339)
+	insertedCreatedDate3 := insertedCompanyPerson3.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, createdDateToInsert3, insertedCreatedDate3)
+}
+
+func TestGetAllCompanyPersons_ShouldReturnNilIfNoPersonsInDatabase(t *testing.T) {
+	companyPersonRepository, _, _ := setupCompanyPersonRepository(t)
+
+	results, err := companyPersonRepository.GetAll()
+	assert.NoError(t, err)
+	assert.Nil(t, results)
+}
+
+// -------- Delete tests: --------
+
+func TestDeleteCompanyPerson_ShouldDeleteCompanyPerson(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	person := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson := models.AssociateCompanyPerson{
+		CompanyID: company.ID,
+		PersonID:  person.ID,
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson)
+	assert.NoError(t, err)
+
+	model := models.DeleteCompanyPerson{
+		CompanyID: company.ID,
+		PersonID:  person.ID,
+	}
+
+	err = companyPersonRepository.Delete(&model)
+	assert.NoError(t, err)
+}
+
+func TestDeleteCompanyPerson_ShouldReturnNotFoundErrorIfNoMatchingCompanyPersonInDatabase(t *testing.T) {
+	companyPersonRepository, companyRepository, personRepository := setupCompanyPersonRepository(t)
+
+	company := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	person := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson := models.AssociateCompanyPerson{
+		CompanyID: company.ID,
+		PersonID:  person.ID,
+	}
+	_, err := companyPersonRepository.AssociateCompanyPerson(&companyPerson)
+	assert.NoError(t, err)
+
+	model := models.DeleteCompanyPerson{
+		CompanyID: uuid.New(),
+		PersonID:  uuid.New(),
+	}
+
+	err = companyPersonRepository.Delete(&model)
+	assert.NotNil(t, err)
+
+	var notFoundError *internalErrors.NotFoundError
+	assert.True(t, errors.As(err, &notFoundError))
+	assert.Equal(t,
+		"error: object not found: CompanyPerson does not exist. companyID: "+model.CompanyID.String()+
+			", personID: "+model.PersonID.String(), notFoundError.Error())
+}

--- a/internal/repositories/company_person_repository_test.go
+++ b/internal/repositories/company_person_repository_test.go
@@ -1,0 +1,51 @@
+package repositories
+
+import (
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/testutil"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetByID_ShouldReturnValidationError(t *testing.T) {
+	tests := []struct {
+		testName  string
+		companyID *uuid.UUID
+		personID  *uuid.UUID
+	}{
+		{
+			testName:  "nil companyID and nil personID ",
+			personID:  nil,
+			companyID: nil,
+		},
+		{
+			testName:  "empty companyID and nil personID",
+			companyID: testutil.ToPtr(uuid.UUID{}),
+			personID:  nil,
+		},
+		{
+			testName:  "nil companyID and empty personID",
+			companyID: nil,
+			personID:  testutil.ToPtr(uuid.UUID{}),
+		},
+		{
+			testName:  "empty companyID and empty personID",
+			companyID: testutil.ToPtr(uuid.UUID{}),
+			personID:  testutil.ToPtr(uuid.UUID{}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			repository := NewCompanyPersonRepository(nil)
+
+			personCompanies, err := repository.GetByID(test.companyID, test.personID)
+			assert.Nil(t, personCompanies)
+
+			assert.NotNil(t, err)
+			assert.Equal(t, internalErrors.NewValidationError(nil, "companyID and personID cannot both be empty"), err)
+		})
+	}
+}

--- a/internal/services/company_person_service.go
+++ b/internal/services/company_person_service.go
@@ -1,0 +1,98 @@
+package services
+
+import (
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/repositories"
+	"log/slog"
+
+	"github.com/google/uuid"
+)
+
+type CompanyPersonService struct {
+	companyPersonRepository *repositories.CompanyPersonRepository
+}
+
+func NewCompanyPersonService(companyPersonRepository *repositories.CompanyPersonRepository) *CompanyPersonService {
+	return &CompanyPersonService{companyPersonRepository: companyPersonRepository}
+}
+
+// AssociateCompanyPerson can return ConflictError, InternalServiceError, ValidationError
+func (companyPersonService *CompanyPersonService) AssociateCompanyPerson(
+	AssociateCompanyPerson *models.AssociateCompanyPerson) (*models.CompanyPerson, error) {
+
+	if AssociateCompanyPerson == nil {
+		slog.Error("person_service.AssociateCompanyPerson: model is nil")
+		return nil, internalErrors.NewValidationError(nil, "AssociateCompanyPerson model is nil")
+	}
+
+	err := AssociateCompanyPerson.Validate()
+	if err != nil {
+		slog.Info("person_service.AssociateCompanyPerson: CompanyPerson to create is invalid", "error", err)
+
+		return nil, err
+	}
+
+	insertedCompanyPerson, err :=
+		companyPersonService.companyPersonRepository.AssociateCompanyPerson(AssociateCompanyPerson)
+
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info(
+		"person_service.AssociateCompanyPerson: Associated company to person.",
+		"person.CompanyID", insertedCompanyPerson.CompanyID,
+		"person.PersonID", insertedCompanyPerson.PersonID)
+	return insertedCompanyPerson, nil
+}
+
+// GetByID can return ValidationError, InternalServiceError
+func (companyPersonService *CompanyPersonService) GetByID(
+	companyID *uuid.UUID, personID *uuid.UUID) ([]*models.CompanyPerson, error) {
+
+	if (companyID == nil || *companyID == uuid.Nil) && (personID == nil || *personID == uuid.Nil) {
+		return nil, internalErrors.NewValidationError(nil, "companyID and personID cannot both be empty")
+	}
+
+	companyPersons, err := companyPersonService.companyPersonRepository.GetByID(companyID, personID)
+	if err != nil {
+		return nil, err
+	}
+
+	if companyPersons == nil {
+		slog.Info("CompanyPersonService.GetByID: Retrieved zero persons")
+	} else {
+		slog.Info(
+			"CompanyPersonService.GetByID: Retrieved " + string(rune(len(companyPersons))) + " persons")
+	}
+
+	return companyPersons, nil
+}
+
+// GetAll can return InternalServiceError
+func (companyPersonService *CompanyPersonService) GetAll() ([]*models.CompanyPerson, error) {
+	companyPersons, err := companyPersonService.companyPersonRepository.GetAll()
+	if err != nil {
+		return nil, err
+	}
+
+	if companyPersons == nil {
+		slog.Info("CompanyPersonService.GetAllCompanyPersons: Retrieved zero persons")
+	} else {
+		slog.Info(
+			"CompanyPersonService.GetAllCompanyPersons: Retrieved " + string(rune(len(companyPersons))) + " persons")
+	}
+
+	return companyPersons, nil
+}
+
+// Delete can return InternalServiceError, NotFoundError, ValidationError
+func (companyPersonService *CompanyPersonService) Delete(model *models.DeleteCompanyPerson) error {
+	err := model.Validate()
+	if err != nil {
+		return err
+	}
+
+	return companyPersonService.companyPersonRepository.Delete(model)
+}

--- a/internal/services/company_person_service_integration_test.go
+++ b/internal/services/company_person_service_integration_test.go
@@ -1,0 +1,354 @@
+package services_test
+
+import (
+	"errors"
+	configPackage "jobsearchtracker/internal/config"
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/repositories"
+	"jobsearchtracker/internal/services"
+	"jobsearchtracker/internal/testutil"
+	"jobsearchtracker/internal/testutil/dependencyinjection"
+	"jobsearchtracker/internal/testutil/repositoryhelpers"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupCompanyPersonService(t *testing.T) (
+	*services.CompanyPersonService, *repositories.CompanyRepository, *repositories.PersonRepository) {
+
+	config := &configPackage.Config{
+		DatabaseMigrationsPath:               "../../migrations",
+		IsDatabaseMigrationsPathAbsolutePath: false,
+	}
+
+	container := dependencyinjection.SetupCompanyPersonServiceTestContainer(t, *config)
+
+	var companyPersonService *services.CompanyPersonService
+	err := container.Invoke(func(service *services.CompanyPersonService) {
+		companyPersonService = service
+	})
+	assert.NoError(t, err)
+
+	var companyRepository *repositories.CompanyRepository
+	err = container.Invoke(func(repository *repositories.CompanyRepository) {
+		companyRepository = repository
+	})
+
+	var personRepository *repositories.PersonRepository
+	err = container.Invoke(func(repository *repositories.PersonRepository) {
+		personRepository = repository
+	})
+
+	return companyPersonService, companyRepository, personRepository
+}
+
+// -------- AssociateCompanyPerson tests: --------
+
+func TestAssociateCompanyToPerson_ShouldAssociateCompaniesToPersons(t *testing.T) {
+	companyPersonService, companyRepository, personRepository := setupCompanyPersonService(t)
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	company2 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	person2 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := models.AssociateCompanyPerson{
+		CompanyID:   company1.ID,
+		PersonID:    person1.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 1)),
+	}
+	_, err := companyPersonService.AssociateCompanyPerson(&companyPerson1)
+	assert.NoError(t, err)
+
+	companyPerson2 := models.AssociateCompanyPerson{
+		CompanyID:   company2.ID,
+		PersonID:    person2.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 2)),
+	}
+	_, err = companyPersonService.AssociateCompanyPerson(&companyPerson2)
+	assert.NoError(t, err)
+
+	companyPerson3 := models.AssociateCompanyPerson{
+		CompanyID:   company2.ID,
+		PersonID:    person1.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 0)),
+	}
+	_, err = companyPersonService.AssociateCompanyPerson(&companyPerson3)
+	assert.NoError(t, err)
+
+	personCompanies, err := companyPersonService.GetAll()
+	assert.NoError(t, err)
+	assert.NotNil(t, personCompanies)
+	assert.Len(t, personCompanies, 3)
+
+	associatedCompanyPerson1 := personCompanies[0]
+	assert.Equal(t, company2.ID, associatedCompanyPerson1.CompanyID)
+	assert.Equal(t, person2.ID, associatedCompanyPerson1.PersonID)
+	assert.NotNil(t, associatedCompanyPerson1.CreatedDate)
+
+	associatedCompanyPerson2 := personCompanies[1]
+	assert.Equal(t, company1.ID, associatedCompanyPerson2.CompanyID)
+	assert.Equal(t, person1.ID, associatedCompanyPerson2.PersonID)
+	assert.NotNil(t, associatedCompanyPerson2.CreatedDate)
+
+	associatedCompanyPerson3 := personCompanies[2]
+	assert.Equal(t, company2.ID, associatedCompanyPerson3.CompanyID)
+	assert.Equal(t, person1.ID, associatedCompanyPerson3.PersonID)
+	assert.NotNil(t, associatedCompanyPerson3.CreatedDate)
+}
+
+// -------- GetByID tests: --------
+
+func TestGetByID_ShouldGetRecordsMatchingCompanyID(t *testing.T) {
+	companyPersonService, companyRepository, personRepository := setupCompanyPersonService(t)
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	company2 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	person2 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := models.AssociateCompanyPerson{
+		CompanyID:   company1.ID,
+		PersonID:    person1.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 1)),
+	}
+	_, err := companyPersonService.AssociateCompanyPerson(&companyPerson1)
+	assert.NoError(t, err)
+
+	companyPerson2 := models.AssociateCompanyPerson{
+		CompanyID:   company1.ID,
+		PersonID:    person2.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 2)),
+	}
+	_, err = companyPersonService.AssociateCompanyPerson(&companyPerson2)
+	assert.NoError(t, err)
+
+	companyPerson3 := models.AssociateCompanyPerson{
+		CompanyID:   company2.ID,
+		PersonID:    person1.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 3)),
+	}
+	_, err = companyPersonService.AssociateCompanyPerson(&companyPerson3)
+	assert.NoError(t, err)
+
+	companyPersons, err := companyPersonService.GetByID(&company1.ID, nil)
+	assert.NoError(t, err)
+	assert.Len(t, companyPersons, 2)
+
+	assert.Equal(t, companyPersons[0].CompanyID, company1.ID)
+	assert.Equal(t, companyPersons[0].PersonID, person2.ID)
+
+	assert.Equal(t, companyPersons[1].CompanyID, company1.ID)
+	assert.Equal(t, companyPersons[1].PersonID, person1.ID)
+}
+
+func TestGetByID_ShouldGetRecordsMatchingPersonID(t *testing.T) {
+	companyPersonService, companyRepository, personRepository := setupCompanyPersonService(t)
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	company2 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	person2 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := models.AssociateCompanyPerson{
+		CompanyID:   company1.ID,
+		PersonID:    person1.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 1)),
+	}
+	_, err := companyPersonService.AssociateCompanyPerson(&companyPerson1)
+	assert.NoError(t, err)
+
+	companyPerson2 := models.AssociateCompanyPerson{
+		CompanyID:   company1.ID,
+		PersonID:    person2.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 2)),
+	}
+	_, err = companyPersonService.AssociateCompanyPerson(&companyPerson2)
+	assert.NoError(t, err)
+
+	companyPerson3 := models.AssociateCompanyPerson{
+		CompanyID:   company2.ID,
+		PersonID:    person1.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 3)),
+	}
+	_, err = companyPersonService.AssociateCompanyPerson(&companyPerson3)
+	assert.NoError(t, err)
+
+	companyPersons, err := companyPersonService.GetByID(nil, &person1.ID)
+	assert.NoError(t, err)
+	assert.Len(t, companyPersons, 2)
+
+	assert.Equal(t, companyPersons[0].CompanyID, company2.ID)
+	assert.Equal(t, companyPersons[0].PersonID, person1.ID)
+
+	assert.Equal(t, companyPersons[1].CompanyID, company1.ID)
+	assert.Equal(t, companyPersons[1].PersonID, person1.ID)
+}
+
+func TestGetByID_ShouldGetRecordsMatchingCompanyIDAndPersonID(t *testing.T) {
+	companyPersonService, companyRepository, personRepository := setupCompanyPersonService(t)
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	company2 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	person2 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := models.AssociateCompanyPerson{
+		CompanyID: company1.ID,
+		PersonID:  person1.ID,
+	}
+	_, err := companyPersonService.AssociateCompanyPerson(&companyPerson1)
+	assert.NoError(t, err)
+
+	companyPerson2 := models.AssociateCompanyPerson{
+		CompanyID: company1.ID,
+		PersonID:  person2.ID,
+	}
+	_, err = companyPersonService.AssociateCompanyPerson(&companyPerson2)
+	assert.NoError(t, err)
+
+	companyPerson3 := models.AssociateCompanyPerson{
+		CompanyID: company2.ID,
+		PersonID:  person1.ID,
+	}
+	_, err = companyPersonService.AssociateCompanyPerson(&companyPerson3)
+	assert.NoError(t, err)
+
+	persons, err := companyPersonService.GetByID(&company1.ID, &person1.ID)
+	assert.NoError(t, err)
+	assert.Len(t, persons, 1)
+	assert.Equal(t, company1.ID, persons[0].CompanyID)
+	assert.Equal(t, person1.ID, persons[0].PersonID)
+}
+
+// -------- GetAll tests: --------
+
+func TestGetAllCompanyPersons_ShouldReturnAllCompanyPersons(t *testing.T) {
+	companyPersonService, companyRepository, personRepository := setupCompanyPersonService(t)
+
+	company1 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	company2 := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+
+	person1 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+	person2 := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson1 := models.AssociateCompanyPerson{
+		CompanyID:   company1.ID,
+		PersonID:    person1.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 1)),
+	}
+	_, err := companyPersonService.AssociateCompanyPerson(&companyPerson1)
+	assert.NoError(t, err)
+
+	companyPerson2 := models.AssociateCompanyPerson{
+		CompanyID:   company1.ID,
+		PersonID:    person2.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 3)),
+	}
+	_, err = companyPersonService.AssociateCompanyPerson(&companyPerson2)
+	assert.NoError(t, err)
+
+	companyPerson3 := models.AssociateCompanyPerson{
+		CompanyID:   company2.ID,
+		PersonID:    person2.ID,
+		CreatedDate: testutil.ToPtr(time.Now().AddDate(0, 0, 2)),
+	}
+	_, err = companyPersonService.AssociateCompanyPerson(&companyPerson3)
+	assert.NoError(t, err)
+
+	personCompanies, err := companyPersonService.GetAll()
+	assert.NoError(t, err)
+
+	assert.Len(t, personCompanies, 3)
+
+	insertedCompanyPerson1 := personCompanies[0]
+	assert.Equal(t, company1.ID, insertedCompanyPerson1.CompanyID)
+	assert.Equal(t, person2.ID, insertedCompanyPerson1.PersonID)
+
+	createdDateToInsert1 := companyPerson2.CreatedDate.Format(time.RFC3339)
+	insertedCreatedDate1 := insertedCompanyPerson1.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, createdDateToInsert1, insertedCreatedDate1)
+
+	insertedCompanyPerson2 := personCompanies[1]
+	assert.Equal(t, company2.ID, insertedCompanyPerson2.CompanyID)
+	assert.Equal(t, person2.ID, insertedCompanyPerson2.PersonID)
+
+	createdDateToInsert2 := companyPerson3.CreatedDate.Format(time.RFC3339)
+	insertedCreatedDate2 := insertedCompanyPerson2.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, createdDateToInsert2, insertedCreatedDate2)
+
+	insertedCompanyPerson3 := personCompanies[2]
+	assert.Equal(t, company1.ID, insertedCompanyPerson3.CompanyID)
+	assert.Equal(t, person1.ID, insertedCompanyPerson3.PersonID)
+
+	createdDateToInsert3 := companyPerson1.CreatedDate.Format(time.RFC3339)
+	insertedCreatedDate3 := insertedCompanyPerson3.CreatedDate.Format(time.RFC3339)
+	assert.Equal(t, createdDateToInsert3, insertedCreatedDate3)
+}
+
+func TestGetAllCompanyPersons_ShouldReturnNilIfNoPersonsInDatabase(t *testing.T) {
+	companyPersonService, _, _ := setupCompanyPersonService(t)
+
+	results, err := companyPersonService.GetAll()
+	assert.NoError(t, err)
+	assert.Nil(t, results)
+}
+
+// -------- Delete tests: --------
+
+func TestDeleteCompanyPerson_ShouldDeleteCompanyPerson(t *testing.T) {
+	companyPersonService, companyRepository, personRepository := setupCompanyPersonService(t)
+
+	company := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	person := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson := models.AssociateCompanyPerson{
+		CompanyID: company.ID,
+		PersonID:  person.ID,
+	}
+	_, err := companyPersonService.AssociateCompanyPerson(&companyPerson)
+	assert.NoError(t, err)
+
+	deleteModel := models.DeleteCompanyPerson{
+		CompanyID: company.ID,
+		PersonID:  person.ID,
+	}
+
+	err = companyPersonService.Delete(&deleteModel)
+	assert.NoError(t, err)
+}
+
+func TestDeleteCompanyPerson_ShouldReturnNotFoundErrorIfNoMatchingCompanyPersonInDatabase(t *testing.T) {
+	companyPersonService, companyRepository, personRepository := setupCompanyPersonService(t)
+
+	company := repositoryhelpers.CreateCompany(t, companyRepository, nil, nil)
+	person := repositoryhelpers.CreatePerson(t, personRepository, nil, nil)
+
+	companyPerson := models.AssociateCompanyPerson{
+		CompanyID: company.ID,
+		PersonID:  person.ID,
+	}
+	_, err := companyPersonService.AssociateCompanyPerson(&companyPerson)
+	assert.NoError(t, err)
+
+	deleteModel := models.DeleteCompanyPerson{
+		CompanyID: uuid.New(),
+		PersonID:  uuid.New(),
+	}
+
+	err = companyPersonService.Delete(&deleteModel)
+	assert.NotNil(t, err)
+
+	var notFoundError *internalErrors.NotFoundError
+	assert.True(t, errors.As(err, &notFoundError))
+	assert.Equal(t,
+		"error: object not found: CompanyPerson does not exist. companyID: "+deleteModel.CompanyID.String()+
+			", personID: "+deleteModel.PersonID.String(), notFoundError.Error())
+}

--- a/internal/services/company_person_service_test.go
+++ b/internal/services/company_person_service_test.go
@@ -1,0 +1,160 @@
+package services
+
+import (
+	internalErrors "jobsearchtracker/internal/errors"
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/testutil"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// -------- AssociateCompanyPerson tests: --------
+
+func TestAssociateCompanyPerson_ShouldReturnValidationErrorIfModelIsNil(t *testing.T) {
+	service := NewCompanyPersonService(nil)
+
+	nilCompany, err := service.AssociateCompanyPerson(nil)
+	assert.Nil(t, nilCompany)
+
+	var validationError *internalErrors.ValidationError
+	assert.ErrorAs(t, err, &validationError)
+
+	assert.Equal(t, validationError.Error(), "validation error: AssociateCompanyPerson model is nil")
+}
+
+func TestAssociateCompanyPerson_ShouldReturnValidationErrorIfModelIsInvalid(t *testing.T) {
+	tests := []struct {
+		testName  string
+		companyID *uuid.UUID
+		personID  *uuid.UUID
+	}{
+		{
+			testName:  "nil companyID and nil personID ",
+			personID:  nil,
+			companyID: nil,
+		},
+		{
+			testName:  "empty companyID and nil personID",
+			companyID: testutil.ToPtr(uuid.UUID{}),
+			personID:  nil,
+		},
+		{
+			testName:  "nil companyID and empty personID",
+			companyID: nil,
+			personID:  testutil.ToPtr(uuid.UUID{}),
+		},
+		{
+			testName:  "empty companyID and empty personID",
+			companyID: testutil.ToPtr(uuid.UUID{}),
+			personID:  testutil.ToPtr(uuid.UUID{}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			service := NewCompanyPersonService(nil)
+
+			personCompanies, err := service.GetByID(test.companyID, test.personID)
+			assert.Nil(t, personCompanies)
+
+			assert.NotNil(t, err)
+			assert.Equal(t, internalErrors.NewValidationError(nil, "companyID and personID cannot both be empty"), err)
+		})
+	}
+
+}
+
+// -------- GetByID tests: --------
+
+func TestGetByID_ShouldReturnValidationErrorIfCompanyIDAndPersonIDAreEmpty(t *testing.T) {
+	tests := []struct {
+		testName  string
+		companyID *uuid.UUID
+		personID  *uuid.UUID
+	}{
+		{
+			testName:  "nil companyID and nil personID ",
+			personID:  nil,
+			companyID: nil,
+		},
+		{
+			testName:  "empty companyID and nil personID",
+			companyID: testutil.ToPtr(uuid.UUID{}),
+			personID:  nil,
+		},
+		{
+			testName:  "nil companyID and empty personID",
+			companyID: nil,
+			personID:  testutil.ToPtr(uuid.UUID{}),
+		},
+		{
+			testName:  "empty companyID and empty personID",
+			companyID: testutil.ToPtr(uuid.UUID{}),
+			personID:  testutil.ToPtr(uuid.UUID{}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			service := NewCompanyPersonService(nil)
+
+			personCompanies, err := service.GetByID(test.companyID, test.personID)
+			assert.Nil(t, personCompanies)
+
+			assert.NotNil(t, err)
+			assert.Equal(t, internalErrors.NewValidationError(nil, "companyID and personID cannot both be empty"), err)
+		})
+	}
+}
+
+// -------- Delete tests: --------
+
+func TestDelete_ShouldReturnValidationErrorIfCompanyIDORPersonIDAreEmpty(t *testing.T) {
+	tests := []struct {
+		testName  string
+		companyID uuid.UUID
+		personID  uuid.UUID
+		errorText string
+	}{
+		{
+			testName:  "empty CompanyID",
+			companyID: uuid.UUID{},
+			personID:  uuid.New(),
+			errorText: "validation error: CompanyID cannot be empty",
+		},
+		{
+			testName:  "empty PersonID",
+			companyID: uuid.New(),
+			personID:  uuid.UUID{},
+			errorText: "validation error: PersonID cannot be empty",
+		},
+		{
+			testName:  "empty CompanyID and PersonID",
+			companyID: uuid.UUID{},
+			personID:  uuid.UUID{},
+			errorText: "validation error: CompanyID cannot be empty",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			service := NewCompanyPersonService(nil)
+
+			deleteModel := models.DeleteCompanyPerson{
+				CompanyID: test.companyID,
+				PersonID:  test.personID,
+			}
+
+			err := service.Delete(&deleteModel)
+			assert.NotNil(t, err)
+
+			var validationError *internalErrors.ValidationError
+			assert.ErrorAs(t, err, &validationError)
+
+			assert.Equal(t, test.errorText, validationError.Error())
+
+		})
+	}
+}

--- a/internal/testutil/dependencyinjection/container.go
+++ b/internal/testutil/dependencyinjection/container.go
@@ -200,3 +200,60 @@ func SetupApplicationHandlerTestContainer(t *testing.T, config configPackage.Con
 
 	return container
 }
+
+// -------- CompanyPerson containers: --------
+
+func SetupCompanyPersonRepositoryTestContainer(t *testing.T, config configPackage.Config) *dig.Container {
+	container := SetupDatabaseTestContainer(t, config)
+
+	err := container.Provide(func(db *sql.DB) *repositories.CompanyPersonRepository {
+		return repositories.NewCompanyPersonRepository(db)
+	})
+	if err != nil {
+		log.Fatal("Failed to provide companyPersonRepository", err)
+	}
+
+	// Add PersonRepository in order to insert data for testing
+	err = container.Provide(func(db *sql.DB) *repositories.PersonRepository {
+		return repositories.NewPersonRepository(db)
+	})
+	if err != nil {
+		log.Fatal("Failed to provide personRepository", err)
+	}
+
+	// Add CompanyRepository in order to insert data for testing
+	err = container.Provide(func(db *sql.DB) *repositories.CompanyRepository {
+		return repositories.NewCompanyRepository(db)
+	})
+	if err != nil {
+		log.Fatal("Failed to provide companyRepository", err)
+	}
+
+	return container
+}
+
+func SetupCompanyPersonServiceTestContainer(t *testing.T, config configPackage.Config) *dig.Container {
+	container := SetupCompanyPersonRepositoryTestContainer(t, config)
+
+	err := container.Provide(func(repository *repositories.CompanyPersonRepository) *services.CompanyPersonService {
+		return services.NewCompanyPersonService(repository)
+	})
+	if err != nil {
+		log.Fatal("Failed to provide companyPersonService", err)
+	}
+
+	return container
+}
+
+func SetupCompanyPersonHandlerTestContainer(t *testing.T, config configPackage.Config) *dig.Container {
+	container := SetupCompanyPersonServiceTestContainer(t, config)
+
+	err := container.Provide(func(service *services.CompanyPersonService) *apiV1.CompanyPersonHandler {
+		return apiV1.NewCompanyPersonHandler(service)
+	})
+	if err != nil {
+		log.Fatal("Failed to provide companyPersonHandler", err)
+	}
+
+	return container
+}

--- a/internal/testutil/repositoryhelpers/repositoryhelpers.go
+++ b/internal/testutil/repositoryhelpers/repositoryhelpers.go
@@ -1,0 +1,49 @@
+package repositoryhelpers
+
+import (
+	"jobsearchtracker/internal/models"
+	"jobsearchtracker/internal/repositories"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func CreateCompany(
+	t *testing.T,
+	companyRepository *repositories.CompanyRepository,
+	companyID *uuid.UUID,
+	createdDate *time.Time) *models.Company {
+
+	company := models.CreateCompany{
+		ID:          companyID,
+		Name:        "CompanyName",
+		CompanyType: models.CompanyTypeEmployer,
+		CreatedDate: createdDate,
+	}
+
+	insertedCompany, err := companyRepository.Create(&company)
+	assert.NoError(t, err)
+
+	return insertedCompany
+}
+
+func CreatePerson(
+	t *testing.T,
+	repository *repositories.PersonRepository,
+	personID *uuid.UUID,
+	createdDate *time.Time) *models.Person {
+
+	person := models.CreatePerson{
+		ID:          personID,
+		Name:        "PersonName",
+		PersonType:  models.PersonTypeUnknown,
+		CreatedDate: createdDate,
+	}
+
+	insertedPerson, err := repository.Create(&person)
+	assert.NoError(t, err)
+
+	return insertedPerson
+}

--- a/migrations/0004_add_company_person.down.sql
+++ b/migrations/0004_add_company_person.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE company_person;

--- a/migrations/0004_add_company_person.up.sql
+++ b/migrations/0004_add_company_person.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS company_person
+(
+    company_id      UUID        NOT NULL,
+    person_id       UUID        NOT NULL,
+    created_date    DATETIME    NOT NULL    DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (company_id, person_id),
+    FOREIGN KEY (company_id) REFERENCES company(id),
+    FOREIGN KEY (person_id) REFERENCES person(id)
+);


### PR DESCRIPTION
- Add new migration to add company_person table.
- Add CompanyPerson models, requests, and responses.
- Add CompanyPerson repository.
- Add CompanyPerson service.
- Add CompanyPerson handlers.
- Update `server` to route new endpoints to handlers.
- Functionality includes associating a company and person, getting by ID, getting all, and deleting.
- Added `repositoryhelpers` class to help with inserting objects for testing.